### PR TITLE
Remove unnecessary exports used in only in tests

### DIFF
--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -25,6 +25,7 @@
 #include <linux/in6.h>
 
 #include "addr.h"
+#include "lib.h"
 #include "log.h"
 #include "tempesta.h"
 
@@ -563,4 +564,4 @@ tfw_addr_fmt(const TfwAddr *addr, char *out_buf, size_t buf_size)
 
 	return (pos - out_buf);
 }
-EXPORT_SYMBOL(tfw_addr_fmt);
+DEBUG_EXPORT_SYMBOL(tfw_addr_fmt);

--- a/tempesta_fw/hash.c
+++ b/tempesta_fw/hash.c
@@ -20,6 +20,7 @@
 
 #include <linux/kernel.h>
 #include "hash.h"
+#include "lib.h"
 
 #define CRCQ(crc, data64) \
 	asm volatile("crc32q %2, %0" : "=r"(crc) : "0"(crc), "r"(data64))
@@ -78,5 +79,5 @@ tail:
 	return crc;
 #undef MUL
 }
-EXPORT_SYMBOL(tfw_hash_str);
+DEBUG_EXPORT_SYMBOL(tfw_hash_str);
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -20,6 +20,7 @@
 #include "gfsm.h"
 #include "http.h"
 #include "http_msg.h"
+#include "lib.h"
 
 TfwHttpMsg *
 tfw_http_msg_alloc(int type)
@@ -45,7 +46,7 @@ tfw_http_msg_alloc(int type)
 
 	return hm;
 }
-EXPORT_SYMBOL(tfw_http_msg_alloc);
+DEBUG_EXPORT_SYMBOL(tfw_http_msg_alloc);
 
 /**
  * The function does not free @m->skb_list, the caller is responsible for that.
@@ -82,4 +83,4 @@ tfw_http_msg_free(TfwHttpMsg *m)
 	}
 	tfw_pool_free(m->pool);
 }
-EXPORT_SYMBOL(tfw_http_msg_free);
+DEBUG_EXPORT_SYMBOL(tfw_http_msg_free);

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -83,6 +83,7 @@
 
 #include "gfsm.h"
 #include "http.h"
+#include "lib.h"
 
 /*
  * ------------------------------------------------------------------------
@@ -1802,8 +1803,7 @@ tfw_http_parse_req(TfwHttpReq *req, unsigned char *data, size_t len)
 
 	return r;
 }
-/* TODO: change to DEBUG_EXPORT_SYMBOL() after merging the 'cfg' branch. */
-EXPORT_SYMBOL(tfw_http_parse_req);
+DEBUG_EXPORT_SYMBOL(tfw_http_parse_req);
 
 /*
  * ------------------------------------------------------------------------

--- a/tempesta_fw/lib.h
+++ b/tempesta_fw/lib.h
@@ -37,4 +37,15 @@
 #define STRINGIFY(x) _STRINGIFY(x)
 #endif
 
+/**
+ * The macro is used instead of EXPORT_SYMBOL() mostly for testing.
+ * Symbols marked with this macro are not exported in a release build and thus
+ * don't pollute the global symbols table.
+ */
+#ifdef DEBUG
+#define DEBUG_EXPORT_SYMBOL(sym) EXPORT_SYMBOL(sym)
+#else
+#define DEBUG_EXPORT_SYMBOL(sym)
+#endif
+
 #endif /* __TFW_LIB_H__ */

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -21,6 +21,7 @@
 #include <linux/kernel.h>
 #include <linux/ctype.h>
 
+#include "lib.h"
 #include "str.h"
 
 #ifndef DEBUG
@@ -115,7 +116,7 @@ tfw_str_add_compound(TfwPool *pool, TfwStr *str)
 
 	return ((TfwStr *)str->ptr + str->len - 1);
 }
-EXPORT_SYMBOL(tfw_str_add_compound);
+DEBUG_EXPORT_SYMBOL(tfw_str_add_compound);
 
 /**
  * Sum length of all chunks in a string (either compound or plain).
@@ -134,7 +135,7 @@ tfw_str_len(const TfwStr *str)
 
 	return total_len;
 }
-EXPORT_SYMBOL(tfw_str_len);
+DEBUG_EXPORT_SYMBOL(tfw_str_len);
 
 /**
  * Generic function for comparing TfwStr and C strings.
@@ -179,7 +180,7 @@ tfw_str_eq_cstr(const TfwStr *str, const char *cstr, int cstr_len,
 
 	return !cstr_len;
 }
-EXPORT_SYMBOL(tfw_str_eq_cstr);
+DEBUG_EXPORT_SYMBOL(tfw_str_eq_cstr);
 
 /**
  * Generic function for comparing TfwStr and a key-value pair of C strings.
@@ -313,7 +314,7 @@ state_val:
 	/* Both @val and the current chunk are finished - full match. */
 	return true;
 }
-EXPORT_SYMBOL(tfw_str_eq_kv);
+DEBUG_EXPORT_SYMBOL(tfw_str_eq_kv);
 
 /**
  * Join all chunks of @str to a single plain C string.
@@ -351,4 +352,4 @@ tfw_str_to_cstr(const TfwStr *str, char *out_buf, int buf_size)
 
 	return (pos - out_buf);
 }
-EXPORT_SYMBOL(tfw_str_to_cstr);
+DEBUG_EXPORT_SYMBOL(tfw_str_to_cstr);


### PR DESCRIPTION
The commit introduces a new macro called DEBUG_EXPORT_SYMBOL().
It acts like the EXPORT_SYMBOL(), but only in a debug build.
In a release build such symbols are eliminated so the global symbol table
is not polluted. That is done for symbols used only in unit tests.

related to: #36