### PR TITLE
Implement back-end server failover.

### DIFF
--- a/tempesta.sh
+++ b/tempesta.sh
@@ -14,7 +14,7 @@ TFW_CACHE_PATH=$TFW_ROOT/cache
 arg=${1:-}
 ss_path=${SYNC_SOCKET:="./"}
 tdb_path=${TDB:="./"}
-sched=${SCHED:="dummy"}
+sched=${SCHED:="rr"}
 
 error()
 {

--- a/tempesta_fw/addr.c
+++ b/tempesta_fw/addr.c
@@ -24,6 +24,7 @@
 #include <linux/in.h>
 #include <linux/in6.h>
 
+#include "addr.h"
 #include "log.h"
 #include "tempesta.h"
 
@@ -326,3 +327,24 @@ tfw_addr_eq(const void *addr1, const void *addr2)
 	}
 }
 EXPORT_SYMBOL(tfw_addr_eq);
+
+ssize_t
+tfw_addr_sa_len(const TfwAddr *addr)
+{
+	sa_family_t family;
+
+	BUG_ON(!addr);
+
+	family = addr->sa.sa_family;
+
+	if (family == AF_INET) {
+		return sizeof(addr->v4);
+	}
+	else if (family == AF_INET6) {
+		return sizeof(addr->v6);
+	}
+	else {
+		TFW_ERR("Bad address family: %d\n", family);
+		return -EINVAL;
+	}
+}

--- a/tempesta_fw/addr.h
+++ b/tempesta_fw/addr.h
@@ -25,11 +25,12 @@
 typedef union {
 	struct sockaddr_in v4;
 	struct sockaddr_in6 v6;
-	struct sockaddr addr;
+	struct sockaddr sa;
 } TfwAddr;
 
 int tfw_inet_pton(char **p, void *addr);
 int tfw_inet_ntop(const void *addr, char *buf);
 bool tfw_addr_eq(const void *addr1, const void *addr2);
+ssize_t tfw_addr_sa_len(const TfwAddr *addr);
 
 #endif /* __TFW_ADDR_H__ */

--- a/tempesta_fw/classifier/req_conn_limit.c
+++ b/tempesta_fw/classifier/req_conn_limit.c
@@ -255,7 +255,7 @@ rcl_http_req_handler(void *obj, unsigned char *data, size_t len)
 {
 	TfwConnection *c = (TfwConnection *)obj;
 
-	return rcl_account_do(c->sess->cli->sock, rcl_req_limit);
+	return rcl_account_do(c->sess->cli_sk, rcl_req_limit);
 }
 
 static TfwClassifier rcl_class_ops = {

--- a/tempesta_fw/client.h
+++ b/tempesta_fw/client.h
@@ -24,8 +24,8 @@ typedef struct {
 	struct sock	*sock;
 } TfwClient;
 
-TfwClient *tfw_create_client(struct sock *s);
-void tfw_destroy_client(struct sock *s);
+TfwClient *tfw_client_alloc(struct sock *s);
+int tfw_client_conn_close(struct sock *sk);
 
 int tfw_client_init(void);
 void tfw_client_exit(void);

--- a/tempesta_fw/if.c
+++ b/tempesta_fw/if.c
@@ -99,7 +99,6 @@ sysctl_addr(ctl_table *ctl, int write, void __user *buffer, size_t *lenp,
 {
 	int r, i;
 	TfwAddrCfg *new_addr = NULL, **cfg_addr = ctl->extra1;
-	int (*reinit)(void) = ctl->extra2;
 
 	if (write) {
 		char *p, *tmp_buf;
@@ -150,8 +149,6 @@ sysctl_addr(ctl_table *ctl, int write, void __user *buffer, size_t *lenp,
 		*cfg_addr = new_addr;
 
 		up_write(&tfw_cfg.mtx);
-
-		r = reinit();
 	}
 
 	return r;
@@ -165,7 +162,6 @@ static ctl_table tfw_ctl_main_tbl[] = {
 		.mode		= 0644,
 		.proc_handler	= sysctl_addr,
 		.extra1		= &tfw_cfg.backends,
-		.extra2		= tfw_sock_backend_refresh_cfg,
 	},
 	{ /* TODO reinitialize/destroy storage on setting/unsetting the var. */
 		.procname	= "cache_enable",

--- a/tempesta_fw/lib.h
+++ b/tempesta_fw/lib.h
@@ -37,4 +37,14 @@
 #define STRINGIFY(x) _STRINGIFY(x)
 #endif
 
+/**
+ * A cleaner replacement for #ifdef DEBUG used to eliminate sections of code
+ * in a release build.
+ */
+#ifdef DEBUG
+#define IF_DEBUG if (1)
+#else
+#define IF_DEBUG if (0)
+#endif
+
 #endif /* __TFW_LIB_H__ */

--- a/tempesta_fw/ptrset.h
+++ b/tempesta_fw/ptrset.h
@@ -1,0 +1,181 @@
+/**
+ *		Tempesta FW
+ *
+ * The TfwPtrSet is a generic set of pointers (implemented as plain array).
+ *
+ * The following operations are defined on the set:
+ *  -
+ *
+ * Copyright (C) 2012-2014 NatSys Lab. (info@natsys-lab.com).
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef __TFW_PTRSET_H__
+#define __TFW_PTRSET_H__
+
+#include "lib.h"
+#include "log.h"
+
+#define TFW_PTRSET_STRUCT(ptr_type, static_max_ptrs) \
+struct {					\
+	atomic_t counter;			\
+	short n;				\
+	short max;				\
+	ptr_type *ptrs[static_max_ptrs];	\
+}
+
+typedef TFW_PTRSET_STRUCT(void, 0) TfwPtrSet;
+
+#define __tfw_ptrset_cast(s) 	\
+({				\
+	BUILD_BUG_ON(offsetof(typeof(*(s)), ptrs) != offsetof(TfwPtrSet, ptrs)); \
+	((TfwPtrSet *)(s)); 	\
+})
+
+#define __tfw_ptrset_max(s) \
+	(ARRAY_SIZE((s)->ptrs) ? ARRAY_SIZE((s)->ptrs) : (s)->max)
+
+#define __tfw_ptrset_size(max) \
+	(sizeof(TfwPtrSet) + ((max) * sizeof(void *)))
+
+#define tfw_ptrset_for_each(ptr, i, s) \
+	for ((i) = 0; ((i) < (s)->n && (ptr = (s)->ptrs[i])); ++(i))
+
+#define tfw_ptrset_is_empty(s) (!(s)->n)
+
+#define tfw_ptrset_add(s, ptr) \
+	__tfw_ptrset_add(__tfw_ptrset_cast(s), ptr, __tfw_ptrset_max(s))
+
+#define tfw_ptrset_del(s, ptr) \
+	__tfw_ptrset_del(__tfw_ptrset_cast(s), ptr, __tfw_ptrset_max(s))
+
+#define tfw_ptrset_purge(s) \
+	__tfw_ptrset_init(__tfw_ptrset_cast(s), __tfw_ptrset_max(s))
+
+#define tfw_ptrset_get_rr(s) \
+	__tfw_ptrset_get_rr(__tfw_ptrset_cast(s), __tfw_ptrset_max(s))
+
+
+static inline void
+__tfw_ptrset_validate(const TfwPtrSet *s, int max)
+{
+	IF_DEBUG {
+		void *ptr1, *ptr2;
+		int idx1, idx2;
+
+		BUG_ON(!s);
+		BUG_ON(max <= 0);
+		BUG_ON(s->n < 0 || s->n > max);
+
+		tfw_ptrset_for_each(ptr1, idx1, s) {
+			BUG_ON(!ptr1);
+			tfw_ptrset_for_each(ptr2, idx2, s) {
+				BUG_ON(ptr1 == ptr2 && idx1 != idx2);
+			}
+		}
+	}
+}
+
+static inline void
+__tfw_ptrset_init(TfwPtrSet *s, int max)
+{
+	memset(s->ptrs, 0, __tfw_ptrset_size(max));
+	s->max = max;
+	__tfw_ptrset_validate(s, max);
+}
+
+static inline int
+__tfw_ptrset_find_idx(const TfwPtrSet *s, const void *ptr, int max)
+{
+	int i;
+
+	__tfw_ptrset_validate(s, max);
+
+	for (i = 0; i < max; ++i) {
+		if (s->ptrs[i] == ptr)
+			return i;
+	}
+
+	return -1;
+}
+
+static inline int
+__tfw_ptrset_add(TfwPtrSet *s, void *ptr, int max)
+{
+	BUG_ON(!ptr);
+
+	if (__tfw_ptrset_find_idx(s, ptr, max) > 0) {
+		TFW_ERR("Can't add ptr %p to set %p - duplicate ptr\n", ptr, s);
+		return -1;
+	}
+	else if (s->n >= s->max) {
+		TFW_ERR("Can't add ptr %p to set %p - set is full\n", ptr, s);
+		return -1;
+	}
+
+	s->ptrs[s->n] = ptr;
+	++s->n;
+
+	return 0;
+}
+
+static inline int
+__tfw_ptrset_del(TfwPtrSet *s, const void *ptr, int max)
+{
+	int i;
+
+	BUG_ON(!ptr);
+
+	i = __tfw_ptrset_find_idx(s, ptr, max);
+
+	if (i < 0) {
+		TFW_ERR("Can't delete ptr %p from set %p - not found\n", ptr, s);
+		return -1;
+	}
+
+	s->ptrs[i] = s->ptrs[s->n - 1];
+	s->ptrs[s->n] = NULL;
+	--s->n;
+
+	return 0;
+}
+
+static inline void *
+__tfw_ptrset_get_rr(TfwPtrSet *s, int max)
+{
+	unsigned int n, counter;
+	void *ret;
+
+	__tfw_ptrset_validate(s, max);
+
+	do {
+		n = s->n;
+		if (unlikely(!n)) {
+			TFW_ERR("Can't get pointer from the empty set: %p\n", s);
+			return NULL;
+		}
+
+		counter = atomic_inc_return(&s->counter);
+		ret = s->ptrs[counter % n];
+	} while (unlikely(!ret));
+
+	return ret;
+}
+
+
+
+
+
+#endif /* __TFW_PTRSET_H__ */

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -228,8 +228,8 @@ alloc_ptrset(TfwPool *pool)
 static TfwServer *
 resolve_addr(const TfwAddr *addr)
 {
-	int i, ret;
-	TfwAddr curr_addr;
+	int i;
+	TfwAddr *curr_addr;
 	TfwServer *curr_srv;
 	TfwServer *out_srv = NULL;
 
@@ -237,12 +237,9 @@ resolve_addr(const TfwAddr *addr)
 
 	for (i = 0; i < added_servers->n; ++i) {
 		curr_srv = added_servers->ptrs[i];
+		curr_addr = &curr_srv->addr;
 
-		ret = tfw_server_get_addr(curr_srv, &curr_addr);
-		if (ret) {
-			LOG("Can't get address of the server: %p\n", curr_srv);
-		}
-		else if (tfw_addr_eq(addr, &curr_addr)) {
+		if (tfw_addr_eq(addr, curr_addr)) {
 			out_srv = curr_srv;
 			break;
 		}

--- a/tempesta_fw/sched/tfw_sched_rr.c
+++ b/tempesta_fw/sched/tfw_sched_rr.c
@@ -229,7 +229,7 @@ tfw_sched_rr_debugfs_hook(bool input, char *buf, size_t size)
 
 	for (i = 0; i < my->servers_n; ++i) {
 		char mark = (i == (my->counter % my->servers_n)) ? '>' : ' ';
-		char srv_str[TFW_MAX_SERVER_STR_SIZE];
+		char srv_str[TFW_SRV_STR_MAX_SIZE];
 
 		tfw_server_snprint(my->servers[i], srv_str, sizeof(srv_str));
 		pos += snprintf(buf + pos, size - pos, "%c%s\n", mark, srv_str);

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -22,21 +22,26 @@
 
 #include <net/sock.h>
 #include "addr.h"
+#include "ptrset.h"
 #include "tempesta.h"
 
-#define TFW_MAX_SERVER_STR_SIZE 100
+#define TFW_SRV_STR_MAX_SIZE 100
+#define TFW_SRV_SOCK_POOL_SIZE 8
+
+typedef TFW_PTRSET_STRUCT(struct sock, TFW_SRV_SOCK_POOL_SIZE) TfwSrvSockPool;
+
 
 typedef struct {
 	/* The server current stress (overloading) value. */
 	int		stress;
 
-	struct sock	*sock;
+	TfwAddr addr;
+	TfwSrvSockPool socks;
 } TfwServer;
 
-TfwServer *tfw_create_server(struct sock *s);
-void tfw_destroy_server(struct sock *s);
+TfwServer *tfw_server_alloc(void);
+void tfw_server_free(TfwServer *srv);
 
-int tfw_server_get_addr(const TfwServer *srv, TfwAddr *addr);
 int tfw_server_snprint(const TfwServer *srv, char *buf, size_t buf_size);
 
 int tfw_server_init(void);

--- a/tempesta_fw/session.c
+++ b/tempesta_fw/session.c
@@ -37,20 +37,22 @@ tfw_session_sched_msg(TfwSession *s, TfwMsg *msg)
 		return -ENOENT;
 	}
 
+#ifdef TODO
 	s->srv = srv;
+#endif
 
 	return 0;
 }
 
 TfwSession *
-tfw_session_create(TfwClient *cli)
+tfw_session_create(struct sock *cli_sk)
 {
 	TfwSession *s = kmem_cache_alloc(sess_cache, GFP_ATOMIC);
 	if (!s)
 		return NULL;
 
-	s->cli = cli;
-	s->srv = NULL;
+	s->cli_sk = cli_sk;
+	s->srv_sk = NULL;
 	INIT_LIST_HEAD(&s->req_list);
 
 	return s;

--- a/tempesta_fw/session.h
+++ b/tempesta_fw/session.h
@@ -33,13 +33,13 @@
  * session.
  */
 typedef struct {
-	TfwServer	*srv;
-	TfwClient	*cli;
+	struct sock 	 *srv_sk;
+	struct sock	 *cli_sk;
 	struct list_head req_list; /* list of pipelined requests */
 } TfwSession;
 
 int tfw_session_sched_msg(TfwSession *s, TfwMsg *msg);
-TfwSession *tfw_session_create(TfwClient *cli);
+TfwSession *tfw_session_create(struct sock *cli_sk);
 void tfw_session_free(TfwSession *s);
 
 int tfw_session_init(void);

--- a/tempesta_fw/tempesta.h
+++ b/tempesta_fw/tempesta.h
@@ -70,6 +70,5 @@ int tfw_if_init(void);
 void tfw_if_exit(void);
 
 int tfw_reopen_listen_sockets(void);
-void tfw_sock_backend_refresh_cfg(void);
 
 #endif /* __TEMPESTA_H__ */


### PR DESCRIPTION
The change introduces a small set of parallel connections to each
TfwServer. They are switched in a round-robin manner when a message
is scheduled. When a connection is closed, another is chosen and the
closed one is re-connected in background.

Also many connections per server implies that TfwSession doesn't link
TfwClient and TfwServer anymore. Instead, it links client/server sockets.