### PR TITLE
switch from sk_destruct to TfwConnection->destruct

### DIFF
--- a/tempesta_fw/client.c
+++ b/tempesta_fw/client.c
@@ -46,8 +46,6 @@ tfw_destroy_client(struct sock *s)
 	conn->hndl = NULL;
 
 	kmem_cache_free(cli_cache, cli);
-
-	conn->sk_destruct(s);
 }
 
 TfwClient *

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -54,9 +54,9 @@ typedef struct {
 	void 		*hndl;	/* TfwClient or TfwServer handler */
 	TfwSession	*sess;	/* currently handled session */
 
-	/* Original sk->sk_destruct. Destructors passed to tfw_connection_new()
-	 * must call it manually. */
-	void (*sk_destruct)(struct sock *sk);
+	/* The callback passed to tfw_connection_new().
+	 * Called before free()'ing the connection when it is closed. */
+	void (*destruct)(struct sock *sk);
 } TfwConnection;
 
 #define TFW_CONN_TYPE(c)	((c)->proto.type)

--- a/tempesta_fw/server.c
+++ b/tempesta_fw/server.c
@@ -56,8 +56,6 @@ tfw_destroy_server(struct sock *s)
 #if 0
 	kmem_cache_free(srv_cache, srv);
 #endif
-
-	conn->sk_destruct(s);
 }
 
 TfwServer *


### PR DESCRIPTION
Before the commit TfwConnection-related code was overwriting the
sk_destruct field of struct sock with a custom destructor function.
The original sk_destruct function was saved in TfwConnection and
had to be called manually from the custom destructor.

This change simply moves the destructor from sk_destruct to the
TfwConnection->destruct field. Now you don't need to call the
original socket destructor manually, and the field was occupied
anyway, so this commit makes code simpler for free.