### PR TITLE
fix check for kernel thread context in tdb_file_open()

### DIFF
--- a/tempesta_db/file.c
+++ b/tempesta_db/file.c
@@ -37,11 +37,10 @@ int
 tdb_file_open(TDB *db, unsigned long size)
 {
 	unsigned long addr, populate;
-	struct mm_struct *mm = current->mm;
 	struct file *filp;
 
 	/* Must be called from kernel thread context. */
-	BUG_ON(mm != &init_mm);
+	BUG_ON(current->mm);
 
 	strcat(db->path, "/" TDB_FNAME);
 


### PR DESCRIPTION
The check is done as following:
	BUG_ON(current->mm != &init_mm);

That triggers a BUG() every time you start Tempesta FW which cache
enabled. The condition is always false because current->mm is NULL
for kernel threads (see linux/Documentation/vm/active_mm.txt).