### PR TITLE
When freeing a message, correctly free SKBs that make the message.

### DIFF
--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -130,22 +130,6 @@ tfw_connection_close(struct sock *sk)
 	return 0;
 }
 
-void
-tfw_connection_send_cli(TfwConnection *conn, TfwMsg *msg)
-{
-	TfwClient *clnt =(TfwClient *)conn->peer;
-
-	ss_send(clnt->sock, &msg->skb_list);
-}
-
-void
-tfw_connection_send_srv(TfwConnection *conn, TfwMsg *msg)
-{
-	TfwServer *srv = (TfwServer *)conn->peer;
-
-	ss_send(srv->sock, &msg->skb_list);
-}
-
 /*
  * ------------------------------------------------------------------------
  * 	Connection Upcalls

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -96,8 +96,6 @@ typedef struct {
 /* Connection downcalls. */
 TfwConnection *tfw_connection_new(struct sock *sk, int type,
 				  void (*destructor)(struct sock *s));
-void tfw_connection_send_cli(TfwConnection *conn, TfwMsg *msg);
-void tfw_connection_send_srv(TfwConnection *conn, TfwMsg *msg);
 
 void tfw_connection_hooks_register(TfwConnHooks *hooks, int type);
 

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -740,19 +740,21 @@ static void
 tfw_http_req_cache_cb(TfwHttpReq *req, TfwHttpResp *resp, void *data)
 {
 	TfwConnection *conn = data;
+	TfwHttpMsg *hm;
 
 	if (resp) {
 		/*
-		 * We have prepared response, send it as is.
+		 * Response prepared, send it as is.
 		 * TODO should we adjust it somehow?
 		 */
-		tfw_connection_send_cli(conn, (TfwMsg *)resp);
+		hm = (TfwHttpMsg *)resp;
 	} else {
+		/* Send request to an appropriate server. */
 		if (tfw_http_adjust_req(req))
 			return;
-		/* Send the request to appropriate server. */
-		tfw_connection_send_srv(conn, (TfwMsg *)req);
+		hm = (TfwHttpMsg *)req;
 	}
+	tfw_http_msg_send(conn, hm);
 }
 
 /**
@@ -915,7 +917,7 @@ tfw_http_resp_process(TfwConnection *conn, unsigned char *data, size_t len)
 		 * The cache frees the response.
 		 */
 		req = (TfwHttpReq *)req_msg;
-		tfw_connection_send_cli(req->conn, (TfwMsg *)resp);
+		tfw_http_msg_send(req->conn, (TfwHttpMsg *)resp);
 
 		tfw_cache_add(resp, req);
 	}

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -113,6 +113,7 @@ typedef struct {
 #define TFW_HTTP_CONN_KA		0x0002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
 #define TFW_HTTP_CHUNKED		0x0004
+#define TFW_HTTP_MSG_OUT		0x0010
 
 /**
  * Common HTTP message members.
@@ -159,6 +160,16 @@ typedef struct {
 	unsigned int	keep_alive;
 	unsigned int	expires;
 } TfwHttpResp;
+
+/*
+ * Send an HTTP message to a peer on a given connection.
+ */
+static inline void
+tfw_http_msg_send(TfwConnection *conn, TfwHttpMsg *hm)
+{
+	hm->flags |= TFW_HTTP_MSG_OUT;
+	ss_send(conn->peer->sock, &hm->msg.skb_list);
+}
 
 typedef void (*tfw_http_req_cache_cb_t)(TfwHttpReq *, TfwHttpResp *, void *);
 

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -45,11 +45,13 @@ tfw_http_msg_free(TfwHttpMsg *m)
 		struct sk_buff *skb = ss_skb_dequeue(&m->msg.skb_list);
 		if (!skb)
 			break;
-		TFW_DBG("free skb %p: truesize=%d sk=%p, destructor=%p"
-			" users=%d\n",
-			skb, skb->truesize, skb->sk, skb->destructor,
-			atomic_read(&skb->users));
-		kfree_skb(skb);
+		if (!(m->flags & TFW_HTTP_MSG_OUT)) {
+			TFW_DBG("free skb %p: truesize=%d sk=%p, destructor=%p"
+				" users=%d\n",
+				skb, skb->truesize, skb->sk, skb->destructor,
+				atomic_read(&skb->users));
+			__kfree_skb(skb);
+		}
 	}
 	tfw_pool_free(m->pool);
 }


### PR DESCRIPTION
This is a solution to #56. The key is knowing whether an SKB is in
Tempesta's full possession or not. It is from the moment it's been
taken out of a socket's receive queue, and until it's sent out, i.e.
put in a socket's send queue. If a message is freed during that time
frame, Tempesta is responsible of freeing SKBs that make the message.
Otherwise, the Linux networking stack will take care of that when it
finishes sending those SKBs out.