### PR TITLE
Modify request processing logic (#119, #111)

### DIFF
--- a/tempesta_fw/sched.c
+++ b/tempesta_fw/sched.c
@@ -50,8 +50,6 @@ tfw_sched_get_srv_conn(TfwMsg *msg)
 
 	read_unlock(&sched_lock);
 
-	TFW_ERR("No server group scheduler\n");
-
 	return NULL;
 }
 


### PR DESCRIPTION
Default operating mode of Tempesta is a Web Server now. If there's
no backend server available, requests should be served from cache.

With this change a response are now looked up in cache. If not found,
an attempt is made to forward the request to a backend server. When
that fails (no backend server available), an HTTP 404 response is sent
to the client. As most of this logic should run after a response is
looked up in cache, it's been moved to tfw_http_req_cache_cb() from
tfw_http_req_process().