### PR TITLE
Add default rule in a correct way (#130)

### DIFF
--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -1358,6 +1358,18 @@ print_parse_error(const TfwCfgParserState *ps)
 		len, start);
 }
 
+/*
+ * Find configuration option specs by option name.
+ * This is a helper function for outside use.
+ * It is used in making dynamic additions to configuration.
+ */
+TfwCfgSpec *
+tfw_cfg_spec_find(TfwCfgSpec specs[], const char *name)
+{
+	return spec_find(specs, name);
+}
+EXPORT_SYMBOL(tfw_cfg_spec_find);
+
 /**
  * The top-level parsing routine.
  *
@@ -1415,6 +1427,7 @@ err:
 	print_parse_error(&ps);
 	return -EINVAL;
 }
+EXPORT_SYMBOL(tfw_cfg_parse_mods_cfg);
 
 /**
  * Parse the @cfg_text with pushing parsed data to modules, and then start

--- a/tempesta_fw/cfg.h
+++ b/tempesta_fw/cfg.h
@@ -288,4 +288,8 @@ int tfw_cfg_map_enum(const TfwCfgEnum mappings[],
 const char *tfw_cfg_get_attr(const TfwCfgEntry *e, const char *attr_key,
 			     const char *default_val);
 
+/* Functions for making dynamic additions to configuration. */
+TfwCfgSpec *tfw_cfg_spec_find(TfwCfgSpec specs[], const char *name);
+int tfw_cfg_parse_mods_cfg(const char *cfg_text, struct list_head *mod_list);
+
 #endif /* __TFW_CFG_H__ */


### PR DESCRIPTION
Use configuration processing code to add the default (wildcard) rule
in a correct way, that facilitates correct release of data structures
when Tempesta is stopped.