### PR TITLE
Eliminate unnecessary SKB postponing (#80)

### DIFF
--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -156,15 +156,3 @@ tfw_connection_put_skb_to_msg(SsProto *proto, struct sk_buff *skb)
 
 	return 0;
 }
-
-int
-tfw_connection_postpone_skb(SsProto *proto, struct sk_buff *skb)
-{
-	TfwConnection *conn = (TfwConnection *)proto;
-
-	TFW_DBG("postpone skb %p\n", skb);
-
-	ss_skb_queue_tail(&conn->msg->skb_list, skb);
-
-	return 0;
-}

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -125,6 +125,5 @@ void tfw_connection_destruct(TfwConnection *conn);
 
 int tfw_connection_recv(struct sock *, unsigned char *, size_t);
 int tfw_connection_put_skb_to_msg(SsProto *, struct sk_buff *);
-int tfw_connection_postpone_skb(SsProto *, struct sk_buff *);
 
 #endif /* __TFW_CONNECTION_H__ */

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1271,7 +1271,13 @@ tfw_http_req_process(TfwConnection *conn, unsigned char *data, size_t len)
 			TFW_DBG("GFSM return code %d\n", r);
 			if (r == TFW_BLOCK)
 				goto block;
-			return TFW_POSTPONE;
+			/*
+			 * TFW_POSTPONE status means that parsing succeeded
+			 * but more data is needed to complete it. Lower layers
+			 * just supply data for parsing. They only want to know
+			 * if processing of a message should continue or not.
+			 */
+			return TFW_PASS;
 		case TFW_PASS:
 			/*
 			 * The request is fully parsed,
@@ -1342,7 +1348,13 @@ tfw_http_resp_process(TfwConnection *conn, unsigned char *data, size_t len)
 				  data, len);
 		if (r == TFW_BLOCK)
 			goto block;
-		return TFW_POSTPONE;
+		/*
+		 * TFW_POSTPONE status means that parsing succeeded
+		 * but more data is needed to complete it. Lower layers
+		 * just supply data for parsing. They only want to know
+		 * if processing of a message should continue or not.
+		 */
+		return TFW_PASS;
 	case TFW_PASS:
 		tfw_http_establish_skb_hdrs((TfwHttpMsg *)resp);
 		r = tfw_gfsm_move(&resp->msg.state, TFW_HTTP_FSM_RESP_MSG,

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1263,14 +1263,14 @@ tfw_http_req_process(TfwConnection *conn, unsigned char *data, size_t len)
 			BUG();
 		case TFW_BLOCK:
 			TFW_DBG("Block bad HTTP request\n");
-			goto block;
+			return TFW_BLOCK;
 		case TFW_POSTPONE:
 			tfw_http_establish_skb_hdrs((TfwHttpMsg *)req);
 			r = tfw_gfsm_move(&req->msg.state,
 					  TFW_HTTP_FSM_REQ_CHUNK, data, len);
 			TFW_DBG("GFSM return code %d\n", r);
 			if (r == TFW_BLOCK)
-				goto block;
+				return TFW_BLOCK;
 			/*
 			 * TFW_POSTPONE status means that parsing succeeded
 			 * but more data is needed to complete it. Lower layers
@@ -1291,7 +1291,7 @@ tfw_http_req_process(TfwConnection *conn, unsigned char *data, size_t len)
 				  TFW_HTTP_FSM_REQ_MSG, data, len);
 		TFW_DBG("GFSM return code %d\n", r);
 		if (r == TFW_BLOCK)
-			goto block;
+			return TFW_BLOCK;
 		conn->msg = NULL;
 
 		tfw_cache_req_process(req, tfw_http_req_cache_cb, NULL);
@@ -1310,8 +1310,6 @@ tfw_http_req_process(TfwConnection *conn, unsigned char *data, size_t len)
 	}
 
 	return r;
-block:
-	return TFW_BLOCK;
 }
 
 /**

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -198,13 +198,9 @@ ss_tcp_process_proto_skb(struct sock *sk, unsigned char *data, size_t len,
 
 	read_lock(&sk->sk_callback_lock);
 	r = SS_CALL(connection_recv, sk, data, len);
-	if (r == SS_POSTPONE) {
-		SS_CALL(postpone_skb, sk->sk_user_data, skb);
-		r = SS_OK;
-	}
 	read_unlock(&sk->sk_callback_lock);
 
-	return r;
+	return (r == SS_POSTPONE) ? SS_OK : r;
 }
 
 /**

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -200,7 +200,7 @@ ss_tcp_process_proto_skb(struct sock *sk, unsigned char *data, size_t len,
 	r = SS_CALL(connection_recv, sk, data, len);
 	read_unlock(&sk->sk_callback_lock);
 
-	return (r == SS_POSTPONE) ? SS_OK : r;
+	return r;
 }
 
 /**

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -169,7 +169,6 @@ static const SsHooks tfw_sock_clnt_ss_hooks = {
 	.connection_drop	= tfw_sock_clnt_drop,
 	.connection_recv	= tfw_connection_recv,
 	.put_skb_to_msg		= tfw_connection_put_skb_to_msg,
-	.postpone_skb		= tfw_connection_postpone_skb,
 };
 
 /*

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -280,7 +280,6 @@ static const SsHooks tfw_sock_srv_ss_hooks = {
 	.connection_error	= tfw_sock_srv_connect_retry,
 	.connection_recv	= tfw_connection_recv,
 	.put_skb_to_msg		= tfw_connection_put_skb_to_msg,
-	.postpone_skb		= tfw_connection_postpone_skb,
 };
 
 /**

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -183,11 +183,6 @@ typedef struct ss_hooks {
 	 * Sync sockets don't free the skbs.
 	 */
 	int (*put_skb_to_msg)(SsProto *proto, struct sk_buff *skb);
-
-	/*
-	 * Postpone the @skb into internal protocol queue.
-	 */
-	int (*postpone_skb)(SsProto *proto, struct sk_buff *skb);
 } SsHooks;
 
 static inline void ss_callback_write_lock(struct sock *sk)


### PR DESCRIPTION
Due to specifics of SKB processing in Tempesta postponing has become
a dummy operation that does nothing and is completely unnecessary.