### PR TITLE
Do not release SKBs that had been handed from Sync Sockets to Tempesta.

### DIFF
--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -101,10 +101,7 @@ tfw_connection_unlink_peer(TfwConnection *conn)
 int
 tfw_connection_new(TfwConnection *conn)
 {
-	int r = TFW_CONN_HOOK_CALL(conn, conn_init);
-	if (r)
-		TFW_DBG("conn_init() hook returned error: %d\n", r);
-	return r;
+	return TFW_CONN_HOOK_CALL(conn, conn_init);
 }
 
 /**

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -500,11 +500,9 @@ tfw_http_conn_destruct(TfwConnection *conn)
 
 	tfw_http_msg_free((TfwHttpMsg *)conn->msg);
 
-	if (TFW_CONN_TYPE(conn) & Conn_Srv) {
-		list_for_each_entry_safe(msg, tmp, &conn->msg_queue, msg_list)
-			tfw_http_msg_free((TfwHttpMsg *)msg);
-		INIT_LIST_HEAD(&conn->msg_queue);
-	}
+	list_for_each_entry_safe(msg, tmp, &conn->msg_queue, msg_list)
+		tfw_http_msg_free((TfwHttpMsg *)msg);
+	INIT_LIST_HEAD(&conn->msg_queue);
 }
 
 /**

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -30,14 +30,12 @@
 #include "sync_socket.h"
 
 /**
- * @prev	- sibling messages sharing the same skb;
  * @msg_list	- messages queue to send to peer;
  * @state	- message processing state;
  * @skb_list	- list of sk_buff's belonging to the message;
  * @len		- total body length;
  */
 typedef struct tfw_msg_t {
-	struct tfw_msg_t	*prev;
 	struct list_head	msg_list;
 	TfwGState		state;
 	SsSkbList		skb_list;

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -130,6 +130,7 @@ tfw_sock_clnt_new(struct sock *sk)
 err_conn_init:
 	tfw_connection_unlink_peer(conn);
 	tfw_connection_unlink_sk(conn);
+	tfw_connection_destruct(conn);
 	tfw_cli_conn_free(conn);
 err_conn_alloc:
 	tfw_client_put(cli);
@@ -158,6 +159,7 @@ tfw_sock_clnt_drop(struct sock *sk)
 
 	tfw_connection_unlink_peer(conn);
 	tfw_connection_unlink_sk(conn);
+	tfw_connection_destruct(conn);
 	tfw_cli_conn_free(conn);
 	tfw_client_put(cli);
 


### PR DESCRIPTION
An SKB had been handed from Sync Sockets to Tempesta already, and then
attached to an HTTP message. From that point on it is managed by Tempesta,
and releasing it in Sync Sockets is wrong.