### PR TITLE
Implement new SKB data processing design

### DIFF
--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -94,6 +94,8 @@ typedef struct {
 	 * required information.
 	 */
 	TfwMsg * (*conn_msg_alloc)(TfwConnection *conn);
+
+	int (*conn_msg_process)(TfwConnection *conn);
 } TfwConnHooks;
 
 /**
@@ -123,7 +125,7 @@ void tfw_connection_unlink_peer(TfwConnection *conn);
 int tfw_connection_new(TfwConnection *conn);
 void tfw_connection_destruct(TfwConnection *conn);
 
-int tfw_connection_recv(struct sock *, unsigned char *, size_t);
-int tfw_connection_put_skb_to_msg(SsProto *, struct sk_buff *);
+int tfw_connection_recv(struct sock *, struct sk_buff *, size_t);
+int tfw_connection_put_skb_to_msg(struct sock *, struct sk_buff *);
 
 #endif /* __TFW_CONNECTION_H__ */

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -204,7 +204,6 @@ int tfw_http_parse_req(TfwHttpReq *req, unsigned char *data, size_t len);
 int tfw_http_parse_resp(TfwHttpResp *resp, unsigned char *data, size_t len);
 
 /* External HTTP functions. */
-int tfw_http_msg_process(void *conn, unsigned char *data, size_t len);
 unsigned long tfw_http_req_key_calc(const TfwHttpReq *req);
 
 /* HTTP message header add/del/sub API */

--- a/tempesta_fw/msg.h
+++ b/tempesta_fw/msg.h
@@ -42,6 +42,7 @@ typedef struct tfw_msg_t {
 	TfwGState		state;
 	SsSkbList		skb_list;
 	size_t			len;
+	size_t			skb_offset;
 } TfwMsg;
 
 #endif /* __TFW_MSG_H__ */

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -190,87 +190,6 @@ ss_send(struct sock *sk, const SsSkbList *skb_list)
 }
 EXPORT_SYMBOL(ss_send);
 
-static int
-ss_tcp_process_proto_skb(struct sock *sk, unsigned char *data, size_t len,
-			 struct sk_buff *skb)
-{
-	int r;
-
-	read_lock(&sk->sk_callback_lock);
-	r = SS_CALL(connection_recv, sk, data, len);
-	read_unlock(&sk->sk_callback_lock);
-
-	return r;
-}
-
-/**
- * Process a socket buffer.
- * See standard skb_copy_datagram_iovec() implementation.
- * @return SS_OK, SS_DROP or negative value of error code.
- *
- * In any case returns with @skb passed to application layer.
- * We don't manege the skb any more.
- */
-static int
-ss_tcp_process_skb(struct sk_buff *skb, struct sock *sk, unsigned int off,
-		   int *count)
-{
-	int i, r = SS_OK;
-	int lin_len = skb_headlen(skb);
-	struct sk_buff *frag_i;
-
-	/*
-	 * We know for sure from the caller that the skb has data.
-	 * No matter where exactly the data is placed, but the skb relates
-	 * to current message, so put it to the message.
-	 */
-	read_lock(&sk->sk_callback_lock);
-	r = SS_CALL(put_skb_to_msg, sk->sk_user_data, skb);
-	read_unlock(&sk->sk_callback_lock);
-	if (r != SS_OK)
-		return r;
-
-	/* Process linear data. */
-	if (off < lin_len) {
-		r = ss_tcp_process_proto_skb(sk, skb->data + off,
-					     lin_len - off, skb);
-		if (r < 0)
-			return r;
-		*count += lin_len - off;
-		off = 0;
-	} else
-		off -= lin_len;
-
-	/* Process paged data. */
-	for (i = 0; i < skb_shinfo(skb)->nr_frags; ++i) {
-		const skb_frag_t *frag = &skb_shinfo(skb)->frags[i];
-		unsigned int f_sz = skb_frag_size(frag);
-		if (f_sz > off) {
-			unsigned char *f_addr = skb_frag_address(frag);
-			r = ss_tcp_process_proto_skb(sk, f_addr + off,
-						     f_sz - off, skb);
-			if (r < 0)
-				return r;
-			*count += f_sz - off;
-			off = 0;
-		} else
-			off -= f_sz;
-	}
-
-	/* Process packet fragments. */
-	skb_walk_frags(skb, frag_i) {
-		if (frag_i->len > off) {
-			r = ss_tcp_process_skb(frag_i, sk, off, count);
-			if (r < 0)
-				return r;
-			off = 0;
-		} else
-			off -= frag_i->len;
-	}
-
-	return r;
-}
-
 /**
  * This is main body of the socket close function in Sync Sockets.
  *
@@ -526,8 +445,19 @@ ss_tcp_process_data(struct sock *sk)
 		if (tcp_hdr(skb)->syn)
 			off--;
 		if (off < skb->len) {
-			int count = 0;
-			int r = ss_tcp_process_skb(skb, sk, off, &count);
+			int r, count = skb->len - off;
+
+			read_lock(&sk->sk_callback_lock);
+			r = SS_CALL(put_skb_to_msg, sk, skb);
+			read_unlock(&sk->sk_callback_lock);
+			if (r != SS_OK) {
+				__kfree_skb(skb);
+				goto out;
+			}
+
+			read_lock(&sk->sk_callback_lock);
+			r = SS_CALL(connection_recv, sk, skb, off);
+			read_unlock(&sk->sk_callback_lock);
 			if (r < 0) {
 				SS_WARN("can't process app data on socket %p\n",
 					sk);
@@ -540,7 +470,6 @@ ss_tcp_process_data(struct sock *sk)
 				 * which will free all the passed and linked
 				 * with currently processed message skbs.
 				 */
-				__kfree_skb(skb);
 				ss_droplink(sk);
 				goto out; /* connection dropped */
 			}

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -171,8 +171,8 @@ typedef struct ss_hooks {
 	int (*connection_error)(struct sock *sk);
 
 	/* Process data received on the socket. */
-	int (*connection_recv)(struct sock *sk, unsigned char *data,
-			       size_t len);
+	int (*connection_recv)(struct sock *sk,
+			       struct sk_buff *skb, size_t offset);
 
 	/*
 	 * Add the @skb to the current connection message.
@@ -182,7 +182,7 @@ typedef struct ss_hooks {
 	 * All the put skbs are owned by the protocol handlers.
 	 * Sync sockets don't free the skbs.
 	 */
-	int (*put_skb_to_msg)(SsProto *proto, struct sk_buff *skb);
+	int (*put_skb_to_msg)(struct sock *sk, struct sk_buff *skb);
 } SsHooks;
 
 static inline void ss_callback_write_lock(struct sock *sk)


### PR DESCRIPTION
A couple of major points:
1. An SKB is handed over to Tempesta from Sync Sockets, and Tempesta becomes
   responsible for it. That includes releasing an SKB when necessary. Because
   of that, processing of data in an SKB is moved to Tempesta. Sync Sockets
   expects now that each SKB is processed in full, and just needs to know if
   processing results in success or failure. Due to connection callback design
   TfwMsg{}.skb_offset is introduced to keep the current offset of data in the
   current SKB.
2. Data is parsed in separate chunks that an SKB holds. In case of pipelined
   HTTP requests processing may stop in the middle of data chunk. However the
   number of parsed bytes is not returned to the caller due to internal design.
   To deal with that, conn->msg is used in combination with TFW_PASS result code.
3. Now SKBs or requests/responses are never used after they were released.