### PR TITLE
cfg: don't try to stop modules if they are not started (fix #143)

### DIFF
--- a/tempesta_fw/cfg.c
+++ b/tempesta_fw/cfg.c
@@ -1622,7 +1622,8 @@ handle_state_change(const char *old_state, const char *new_state)
 	}
 	if (!strcasecmp("stop", new_state)) {
 		TFW_LOG("stopping all modules...\n");
-		tfw_cfg_stop_mods(&tfw_cfg_mods);
+		if (tfw_cfg_mods_are_started)
+			tfw_cfg_stop_mods(&tfw_cfg_mods);
 		tfw_cfg_mods_are_started = false;
 		return 0;
 	}


### PR DESCRIPTION
With the fix it behaves something like that.
./tempesta.sh start
```
[  304.731826] [tdb] Start Tempesta DB
[  304.767132] [tempesta] Initializing Tempesta FW kernel module...
[  304.780229] [tempesta] init: cfg_if
[  304.781385] [tempesta] init: tls
[  304.782122] [tempesta] init: http
[  304.782933] [tempesta] init: http_sticky
[  304.789132] [tempesta] init: server
[  304.789954] [tempesta] init: client
[  304.790979] [tempesta] init: sock_srv
[  304.792301] [tempesta] init: sock_clnt
[  304.793237] [tempesta]   register cfg: filter
[  304.794190] [tempesta]   register cfg: cache
[  304.795146] [tempesta]   register cfg: http_sticky
[  304.796183] [tempesta]   register cfg: sock_srv
[  304.797150] [tempesta]   register cfg: sock_clnt
[  304.813051] [tempesta] Registering new scheduler: dummy
[  304.825641] [tempesta]   tfw_sched_hash: init
[  304.826741] [tempesta] Registering new scheduler: hash
[  304.842911] [tempesta]   tfw_sched_http: init
[  304.844086] [tempesta]   register cfg: tfw_sched_http
[  304.845235] [tempesta] Registering new scheduler: http
[  304.856654] [tempesta]   tfw_sched_rr: init
[  304.857639] [tempesta] Registering new scheduler: round-robin
[  304.869655] [tempesta] got state via sysctl: start
[  304.872281] [tempesta]   reading configuration file...
[  304.873425] [tempesta]   reading file: /root/tempesta/etc/tempesta_fw.conf
[  304.880305] [tempesta]   file size: 5790 bytes
[  304.881464] [tempesta]   read by offset: 0
[  304.883135] [tempesta]   read by offset: 4096
[  304.884190] [tempesta]   read by offset: 5790
[  304.885200] [tempesta] starting all modules...
[  304.886256] [tempesta]   parsing configuration and pushing it to modules...
[  304.888258] [tempesta]   spec handle: 'listen'
[  304.889273] [tempesta] ERROR: invalid number of values; expected: 1, got: 2
[  304.890748] [tempesta] ERROR: Unable to parse 'listen' value: 'No value specified'
[  304.892331] [tempesta] ERROR: configuration handler returned error: -22
[  304.893783] [tempesta] ERROR: configuration parsing error:
[  304.893783] #   listen [::1]:8001;
[  304.893783] #
[  304.893783] # Default:
[  304.893783] #   listen 80;
[  304.893783] listen 127.0.0.1:81 f;
[  304.893783] listen
[  304.893783] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[  304.899201] [tempesta] ERROR: can't parse configuration data
[  304.900490] [tempesta]   spec cleanup: 'listen'
[  304.930038] [tempesta] ERROR: failed to start modules
```
./tempesta.sh stop
```
[  310.790728] [tempesta] got state via sysctl: stop
[  310.791770] [tempesta] stopping all modules...
[  310.810301] [tempesta] Un-registering scheduler: dummy
[  310.821971] [tempesta]   tfw_sched_hash: exit
[  310.845214] [tempesta] Un-registering scheduler: hash
[  310.864865] [tempesta]   tfw_sched_http: exit
[  310.865882] [tempesta] Un-registering scheduler: http
[  310.866939] [tempesta]   unregister cfg: tfw_sched_http
[  310.877407] [tempesta]   tfw_sched_rr: exit
[  310.899054] [tempesta] Un-registering scheduler: round-robin
[  310.904364] [tempesta] exiting...
[  310.905404] [tempesta]   stopping and unregistering all cfg modules
[  310.906828] [tempesta]   unregister cfg: sock_clnt
[  310.907834] [tempesta]   unregister cfg: sock_srv
[  310.908817] [tempesta]   unregister cfg: http_sticky
[  310.909862] [tempesta]   unregister cfg: cache
[  310.911080] [tempesta]   unregister cfg: filter
[  310.915813] [tdb] Shutdown Tempesta DB
```