### PR TITLE
Implement new architecture for processing data in Tempesta (#138)

### DIFF
--- a/tempesta_fw/Makefile
+++ b/tempesta_fw/Makefile
@@ -48,6 +48,7 @@ tempesta_fw-objs = \
 	sock.o \
 	sock_clnt.o \
 	sock_srv.o \
+	ss_skb.o \
 	stress.o \
 	str.o \
 	tls.o

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -491,16 +491,17 @@ st: __attribute__((unused))						\
 	__FSM_EXIT()
 
 static int
-frang_http_req_handler(void *obj, unsigned char *data, size_t len)
+frang_http_req_handler(void *obj, struct sk_buff *skb, unsigned int off)
 {
 	int r = TFW_PASS;
-	unsigned int body_len = len;
+	unsigned int body_len = skb->len - off;
 	TfwConnection *conn = (TfwConnection *)obj;
 	TfwHttpReq *req = container_of(conn->msg, TfwHttpReq, msg);
 	struct sk_buff *head_skb = (void *)ss_skb_peek(&req->msg.skb_list);
-	struct sk_buff *skb = (void *)ss_skb_peek_tail(&req->msg.skb_list);
 
 	__FSM_INIT();
+
+	skb = (void *)ss_skb_peek_tail(&req->msg.skb_list);
 
 	/*
 	 * There's no need to check for header timeout if this is the very

--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -130,11 +130,11 @@ tfw_connection_send(TfwConnection *conn, TfwMsg *msg)
  * the use of sk->sk_user_data.
  */
 int
-tfw_connection_recv(struct sock *sk, unsigned char *data, size_t len)
+tfw_connection_recv(struct sock *sk, struct sk_buff *skb, unsigned int off)
 {
 	TfwConnection *conn = sk->sk_user_data;
 
-	return tfw_gfsm_dispatch(conn, data, len);
+	return tfw_gfsm_dispatch(conn, skb, off);
 }
 
 int

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -123,7 +123,7 @@ void tfw_connection_unlink_peer(TfwConnection *conn);
 int tfw_connection_new(TfwConnection *conn);
 void tfw_connection_destruct(TfwConnection *conn);
 
-int tfw_connection_recv(struct sock *, unsigned char *, size_t);
+int tfw_connection_recv(struct sock *sk, struct sk_buff *skb, unsigned int off);
 int tfw_connection_put_skb_to_msg(SsProto *, struct sk_buff *);
 
 #endif /* __TFW_CONNECTION_H__ */

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -124,6 +124,5 @@ int tfw_connection_new(TfwConnection *conn);
 void tfw_connection_destruct(TfwConnection *conn);
 
 int tfw_connection_recv(struct sock *sk, struct sk_buff *skb, unsigned int off);
-int tfw_connection_put_skb_to_msg(SsProto *, struct sk_buff *);
 
 #endif /* __TFW_CONNECTION_H__ */

--- a/tempesta_fw/gfsm.c
+++ b/tempesta_fw/gfsm.c
@@ -118,11 +118,11 @@ tfw_gfsm_pop_ctx(TfwGState *st)
  * Dispatch connection data to proper FSM.
  */
 int
-tfw_gfsm_dispatch(void *obj, unsigned char *data, size_t len)
+tfw_gfsm_dispatch(void *obj, struct sk_buff *skb, unsigned int off)
 {
 	SsProto *proto = (SsProto *)obj;
 
-	return fsm_htbl[TFW_FSM_TYPE(proto->type)](obj, data, len);
+	return fsm_htbl[TFW_FSM_TYPE(proto->type)](obj, skb, off);
 }
 
 /**
@@ -136,8 +136,8 @@ tfw_gfsm_dispatch(void *obj, unsigned char *data, size_t len)
  * has 32-bit states bitmap), so we use this fact to speedup the iteration.
  */
 int
-tfw_gfsm_move(TfwGState *st, unsigned short new_state, unsigned char *data,
-	      size_t len)
+tfw_gfsm_move(TfwGState *st, unsigned short new_state, struct sk_buff *skb,
+	      unsigned int off)
 {
 	int r = TFW_PASS, p;
 	unsigned int *wc = st->wish_call[st->st_p];
@@ -158,7 +158,7 @@ tfw_gfsm_move(TfwGState *st, unsigned short new_state, unsigned char *data,
 		 * There is possible recursion when the new FSM moves through
 		 * its states.
 		 */
-		r = tfw_gfsm_dispatch(st->obj, data, len);
+		r = tfw_gfsm_dispatch(st->obj, skb, off);
 		/*
 		 * XXX Should we continue processing for lower priorities
 		 * if current FSM is still in progress?

--- a/tempesta_fw/gfsm.h
+++ b/tempesta_fw/gfsm.h
@@ -224,12 +224,13 @@ typedef struct {
 
 #define TFW_GFSM_STATE(s)	(s)->st_stack[(s)->st_p]
 
-typedef int (*tfw_gfsm_handler_t)(void *obj, unsigned char *data, size_t len);
+typedef int (*tfw_gfsm_handler_t)(void *obj, struct sk_buff *skb,
+				  unsigned int off);
 
 void tfw_gfsm_state_init(TfwGState *st, void *obj, int st0);
-int tfw_gfsm_dispatch(void *obj, unsigned char *data, size_t len);
-int tfw_gfsm_move(TfwGState *st, unsigned short new_state, unsigned char *data,
-		  size_t len);
+int tfw_gfsm_dispatch(void *obj, struct sk_buff *skb, unsigned int off);
+int tfw_gfsm_move(TfwGState *st, unsigned short new_state, struct sk_buff *skb,
+		  unsigned int off);
 
 int tfw_gfsm_register_hook(int fsm_id, int prio, int state,
 			   unsigned short hndl_fsm_id, int st0);

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -1262,14 +1262,15 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 		/*
 		 * Process/parse data in the SKB.
 		 * @off points at the start of data for processing.
-		 * After processing @data_off points at the end of current
-		 * data chunk. However processing may have stopped in the
-		 * middle of the chunk. Adjust it to point to the right
-		 * location within the chunk.
+		 * @data_off is the current offset of data to process in
+		 * the SKB. After processing @data_off points at the end
+		 * of latest data chunk. However processing may have
+		 * stopped in the middle of the chunk. Adjust it to point 
+		 * to the right location within the chunk.
 		 */
 		off = data_off;
 		r = ss_skb_process(skb, &data_off, tfw_http_parse_req, hmreq);
-		data_off -= parser->data_len - parser->data_off;
+		data_off -= parser->to_go;
 		hmreq->msg.len += data_off - off;
 
 		TFW_DBG("Request parsed: len=%u parsed=%d msg_len=%lu res=%d\n",
@@ -1330,7 +1331,6 @@ tfw_http_req_process(TfwConnection *conn, struct sk_buff *skb, unsigned int off)
 					 "to create request sibling\n");
 				return TFW_BLOCK;
 			}
-			tfw_http_parser_msg_inherit(hmreq, hmsib);
 		}
 		/*
 		 * The request should either be stored or released.

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -212,11 +212,11 @@ typedef void (*tfw_http_req_cache_cb_t)(TfwHttpReq *, TfwHttpResp *, void *);
 
 /* Internal (parser) HTTP functions. */
 void tfw_http_parser_msg_inherit(TfwHttpMsg *hm, TfwHttpMsg *hm_new);
-int tfw_http_parse_req(TfwHttpReq *req, unsigned char *data, size_t len);
-int tfw_http_parse_resp(TfwHttpResp *resp, unsigned char *data, size_t len);
+int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
+int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 
 /* External HTTP functions. */
-int tfw_http_msg_process(void *conn, unsigned char *data, size_t len);
+int tfw_http_msg_process(void *conn, struct sk_buff *skb, unsigned int off);
 unsigned long tfw_http_req_key_calc(TfwHttpReq *req);
 
 /* HTTP message header add/del/sub API */

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -69,20 +69,19 @@ typedef struct {
  *
  * @state	- current parser state;
  * @_i_st	- helping (interior) state;
- * @cdc_len	- current data chunk length;
- * @data_off	- data offset from which the parser starts reading;
+ * @data_len	- length of the data chunk currently being processed;
+ * @data_off	- offset in the data chunk currently being processed;
  *		  (the two above are limited by skb data chunk size,
  *		   so they're never more than 64KB)
- * @to_read	- remaining data to read;
- * @_tmp_chunk	- stores begin of currently processed string at the end
- * 		  of last skb;
- * @hdr		- currently parsed header
+ * @to_read	- remaining number of bytes to read;
+ * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
+ * @hdr		- currently parsed header.
  */
 typedef struct tfw_http_parser {
 	unsigned char	flags;
 	int		state;
 	int		_i_st;
-	unsigned short	cdc_len;
+	unsigned short	data_len;
 	unsigned short	data_off;
 	int		to_read;
 	TfwStr		_tmp_chunk;

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -72,7 +72,7 @@ typedef struct {
  * @data_len	- length of the data chunk currently being processed;
  * @data_off	- offset in the data chunk currently being processed;
  *		  (the two above are limited by skb data chunk size,
- *		   so they're never more than 64KB)
+ *		   so they never exceed 64KB value)
  * @to_read	- remaining number of bytes to read;
  * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
  * @hdr		- currently parsed header.

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -69,20 +69,17 @@ typedef struct {
  *
  * @state	- current parser state;
  * @_i_st	- helping (interior) state;
- * @data_len	- length of the data chunk currently being processed;
- * @data_off	- offset in the data chunk currently being processed;
- *		  (the two above are limited by skb data chunk size,
- *		   so they never exceed 64KB value)
+ * @to_go	- remaining number of bytes to process in the data chunk;
+ *		  (limited by single packet size and never exceeds 64KB)
  * @to_read	- remaining number of bytes to read;
  * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
  * @hdr		- currently parsed header.
  */
 typedef struct tfw_http_parser {
 	unsigned char	flags;
+	unsigned short	to_go;
 	int		state;
 	int		_i_st;
-	unsigned short	data_len;
-	unsigned short	data_off;
 	int		to_read;
 	TfwStr		_tmp_chunk;
 	TfwStr		hdr;
@@ -220,7 +217,6 @@ typedef struct {
 typedef void (*tfw_http_req_cache_cb_t)(TfwHttpReq *, TfwHttpResp *, void *);
 
 /* Internal (parser) HTTP functions. */
-void tfw_http_parser_msg_inherit(TfwHttpMsg *hm, TfwHttpMsg *hm_new);
 int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -66,17 +66,27 @@ typedef struct {
  * @_i_st is used to save current state and go to interior sub-automaton
  * (e.g. process LWS using @state while current state is saved in @_i_st
  * or using @_i_st parse value of a header described
+ *
+ * @state	- current parser state;
+ * @_i_st	- helping (interior) state;
+ * @cdc_len	- current data chunk length;
+ * @data_off	- data offset from which the parser starts reading;
+ *		  (the two above are limited by skb data chunk size,
+ *		   so they're never more than 64KB)
+ * @to_read	- remaining data to read;
+ * @_tmp_chunk	- stores begin of currently processed string at the end
+ * 		  of last skb;
+ * @hdr		- currently parsed header
  */
 typedef struct tfw_http_parser {
 	unsigned char	flags;
-	int		state;		/* current parser state */
-	int		_i_st;		/* helping (interior) state */
-	int		data_off;	/* data offset from which the parser
-					   starts reading */
-	int		to_read;	/* remaining data to read */
-	TfwStr		_tmp_chunk;	/* stores begin of currently processed
-					   string at the end of last skb */
-	TfwStr		hdr;		/* currently parsed header */
+	int		state;
+	int		_i_st;
+	unsigned short	cdc_len;
+	unsigned short	data_off;
+	int		to_read;
+	TfwStr		_tmp_chunk;
+	TfwStr		hdr;
 } TfwHttpParser;
 
 /**

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -2,7 +2,7 @@
  *		Tempesta FW
  *
  * Copyright (C) 2012-2014 NatSys Lab. (info@natsys-lab.com).
- * Copyright (C) 2015 Tempesta Technologies.
+ * Copyright (C) 2015 Tempesta Technologies, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by

--- a/tempesta_fw/http_msg.c
+++ b/tempesta_fw/http_msg.c
@@ -23,9 +23,6 @@
 #include "http_msg.h"
 #include "lib.h"
 
-/**
- * The function does not free @m->skb_list, the caller is responsible for that.
- */
 void
 tfw_http_msg_free(TfwHttpMsg *m)
 {
@@ -39,8 +36,8 @@ tfw_http_msg_free(TfwHttpMsg *m)
 
 	while (1) {
 		/*
-		 * The skbs are passed to us by put_skb_to_msg() call,
-		 * so we're responsible to free them.
+		 * The SKBs are handed to Tempesta from the lower layer.
+		 * Tempesta is responsible for releasing them.
 		 */
 		struct sk_buff *skb = ss_skb_dequeue(&m->msg.skb_list);
 		if (!skb)

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -117,7 +117,7 @@ do {									\
 done:									\
 	parser->state = __fsm_const_state;				\
 	/* Remember lengths to get correct offset of next message. */	\
-	parser->cdc_len = len;						\
+	parser->data_len = len;						\
 	parser->data_off = p - data;
 
 #define ____FSM_MOVE_LAMBDA(to, n, code)				\

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -77,13 +77,15 @@ __field_finish(TfwStr *field, unsigned char *begin, unsigned char *end)
  * used in the defines below here to reduce stack frame usage.
  * Since the variables are global now, be careful with them.
  */
-#define __FSM_START(s)							\
+#define __FSM_DECLARE_VARS()						\
 int __fsm_const_state;							\
 /* Declare FSM automatic variables, the variables have only local sense. */ \
 int __fsm_n;								\
 size_t __fsm_sz __attribute__((unused));				\
 unsigned char *__fsm_ch __attribute__((unused));			\
-TfwStr *__fsm_str;							\
+TfwStr *__fsm_str;
+
+#define __FSM_START(s)							\
 parser->data_off = 0; /* new data chunk */				\
 fsm_reenter: __attribute__((unused))					\
 	TFW_DBG("enter FSM at state %d\n", s);				\
@@ -654,6 +656,7 @@ __parse_connection(TfwHttpMsg *msg, unsigned char *data, size_t *lenrval)
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -743,6 +746,7 @@ __parse_content_length(TfwHttpMsg *msg, unsigned char *data, size_t *lenrval)
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -789,6 +793,7 @@ __parse_transfer_encoding(TfwHttpMsg *msg, unsigned char *data, size_t *lenrval)
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -1242,6 +1247,7 @@ __req_parse_cache_control(TfwHttpReq *req, unsigned char *data, size_t *lenrval)
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -1371,6 +1377,7 @@ __req_parse_host(TfwHttpReq *req, unsigned char *data, size_t *lenrval)
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -1428,6 +1435,7 @@ __req_parse_x_forwarded_for(TfwHttpReq *req, unsigned char *data,
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -1494,13 +1502,18 @@ done:
 }
 
 int
-tfw_http_parse_req(TfwHttpReq *req, unsigned char *data, size_t len)
+tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 {
+	TfwHttpReq *req = (TfwHttpReq *)req_data;
 	TfwHttpParser *parser = &req->parser;
 	TfwHttpMsg *msg = (TfwHttpMsg *)req;
 	int r = TFW_BLOCK;
 	unsigned char *p = data;
 	unsigned char c = *p;
+	__FSM_DECLARE_VARS();
+
+	TFW_DBG("parse %lu client data bytes (%.*s) on req=%p\n",
+		len, (int)len, data, req);
 
 	__FSM_START(parser->state) {
 
@@ -2002,6 +2015,7 @@ __resp_parse_cache_control(TfwHttpResp *resp, unsigned char *data, size_t *lenrv
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -2183,6 +2197,7 @@ __resp_parse_expires(TfwHttpResp *resp, unsigned char *data, size_t *lenrval)
 	int r = CSTR_NEQ;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -2368,6 +2383,7 @@ __resp_parse_keep_alive(TfwHttpResp *resp, unsigned char *data, size_t *lenrval)
 	size_t len = *lenrval;
 	unsigned char c = *p;
 	bool hlen_set = false;
+	__FSM_DECLARE_VARS();
 
 	__FSM_START(parser->_i_st) {
 
@@ -2541,13 +2557,18 @@ enum {
 };
 
 int
-tfw_http_parse_resp(TfwHttpResp *resp, unsigned char *data, size_t len)
+tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 {
+	TfwHttpResp *resp = (TfwHttpResp *)resp_data;
 	TfwHttpParser *parser = &resp->parser;
 	TfwHttpMsg *msg = (TfwHttpMsg *)resp;
 	int r = TFW_BLOCK;
 	unsigned char *p = data;
 	unsigned char c = *p;
+	__FSM_DECLARE_VARS();
+
+	TFW_DBG("parse %lu server data bytes (%.*s) on resp=%p\n",
+		len, (int)len, data, resp);
 
 	__FSM_START(parser->state) {
 

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -116,7 +116,9 @@ do {									\
 #define __FSM_FINISH(m)							\
 done:									\
 	parser->state = __fsm_const_state;				\
-	parser->data_off = p - data;					\
+	/* Remember lengths to get correct offset of next message. */	\
+	parser->cdc_len = len;						\
+	parser->data_off = p - data;
 
 #define ____FSM_MOVE_LAMBDA(to, n, code)				\
 do {									\

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -86,7 +86,6 @@ unsigned char *__fsm_ch __attribute__((unused));			\
 TfwStr *__fsm_str;
 
 #define __FSM_START(s)							\
-parser->data_off = 0; /* new data chunk */				\
 fsm_reenter: __attribute__((unused))					\
 	TFW_DBG("enter FSM at state %d\n", s);				\
 switch (s)
@@ -116,9 +115,8 @@ do {									\
 #define __FSM_FINISH(m)							\
 done:									\
 	parser->state = __fsm_const_state;				\
-	/* Remember lengths to get correct offset of next message. */	\
-	parser->data_len = len;						\
-	parser->data_off = p - data;
+	/* Remaining number of bytes to process in the data chunk. */	\
+	parser->to_go = len - (size_t)(p - data);
 
 #define ____FSM_MOVE_LAMBDA(to, n, code)				\
 do {									\
@@ -221,15 +219,6 @@ static const unsigned long hdr_a[] ____cacheline_aligned = {
 };
 
 #define IN_ALPHABET(c, a)	(a[c >> 6] & (1UL << (c & 0x3f)))
-
-/**
- * Prepare the parser to process a new message in the same data chunk.
- */
-void
-tfw_http_parser_msg_inherit(TfwHttpMsg *hm, TfwHttpMsg *hm_new)
-{
-	hm_new->parser.data_off = hm->parser.data_off;
-}
 
 #define CSTR_EQ			0
 #define CSTR_POSTPONE		TFW_POSTPONE	/* -1 */

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -447,25 +447,13 @@ ss_tcp_process_data(struct sock *sk)
 		if (off < skb->len) {
 			int r, count = skb->len - off;
 
-			read_lock(&sk->sk_callback_lock);
-
 			/*
-			 * We know for sure from the caller that the skb
-			 * relates to current message, so put it to the message
-			 * skb list.
-			 *
-			 * Hereafter skb is passed to higher protocol handler
-			 * and must be freed there.
+			 * We know that data for processing is within
+			 * the current SKB. Hand the SKB over to the
+			 * upper layer for processing.
 			 */
-			r = SS_CALL(put_skb_to_msg, sk->sk_user_data, skb);
-			if (r != SS_OK) {
-				read_unlock(&sk->sk_callback_lock);
-				__kfree_skb(skb);
-				goto out;
-			}
-
+			read_lock(&sk->sk_callback_lock);
 			r = SS_CALL(connection_recv, sk, skb, off);
-
 			read_unlock(&sk->sk_callback_lock);
 
 			if (r < 0) {

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -168,7 +168,6 @@ static const SsHooks tfw_sock_clnt_ss_hooks = {
 	.connection_new		= tfw_sock_clnt_new,
 	.connection_drop	= tfw_sock_clnt_drop,
 	.connection_recv	= tfw_connection_recv,
-	.put_skb_to_msg		= tfw_connection_put_skb_to_msg,
 };
 
 /*

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -279,7 +279,6 @@ static const SsHooks tfw_sock_srv_ss_hooks = {
 	.connection_drop	= tfw_sock_srv_connect_failover,
 	.connection_error	= tfw_sock_srv_connect_retry,
 	.connection_recv	= tfw_connection_recv,
-	.put_skb_to_msg		= tfw_connection_put_skb_to_msg,
 };
 
 /**

--- a/tempesta_fw/ss_skb.c
+++ b/tempesta_fw/ss_skb.c
@@ -1,0 +1,87 @@
+/**
+ *		Tempesta FW
+ *
+ * Helpers for Linux socket buffers manipulation.
+ *
+ * Application protocol handler layers must inplement zero data copy logic
+ * on top on native Linux socket buffers. The helpers provide common and
+ * convenient wrappers for skb processing.
+ *
+ * Copyright (C) 2015 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#include "ss_skb.h"
+
+/**
+ * Process a socket buffer.
+ * See standard skb_copy_datagram_iovec() implementation.
+ * @return SS_OK, SS_DROP or negative value of error code.
+ *
+ * The function is anaware about application layer, but it still chops
+ * @skb to messages: if @proc_actor returns POSTPONE code and there is more
+ * data in @skb, then function continues to process @skb, otherwise it
+ * returns allowing higher layer to process the full message.
+ * @off is used as an iterator among the function calls over the same @skb.
+ */
+int
+ss_skb_process(struct sk_buff *skb, unsigned int *off,
+	       ss_skb_proc_actor_t proc_actor, void *data)
+{
+	int i, r = SS_OK;
+	int lin_len = skb_headlen(skb);
+	unsigned int o = *off;
+	struct sk_buff *frag_i;
+
+	/* Process linear data. */
+	if (o < lin_len) {
+		*off = lin_len;
+		r = proc_actor(data, skb->data + o, lin_len - o);
+		if (r != SS_POSTPONE)
+			return r;
+		o = 0;
+	} else
+		o -= lin_len;
+
+	/* Process paged data. */
+	for (i = 0; i < skb_shinfo(skb)->nr_frags; ++i) {
+		const skb_frag_t *frag = &skb_shinfo(skb)->frags[i];
+		unsigned int f_sz = skb_frag_size(frag);
+		if (f_sz > o) {
+			unsigned char *f_addr = skb_frag_address(frag);
+			*off += f_sz - o;
+			r = ss_tcp_process_proto_skb(sk, f_addr + o,
+						     f_sz - o, skb);
+			if (r != SS_POSTPONE)
+				return r;
+			o = 0;
+		} else
+			o -= f_sz;
+	}
+
+	/* Process packet fragments. */
+	skb_walk_frags(skb, frag_i) {
+		if (frag_i->len > o) {
+			*off += frag_i->len - o;
+			r = ss_skb_process(frag_i, o, proc_actor, data);
+			if (r != SS_POSTPONE)
+				return r;
+			o = 0;
+		} else
+			o -= frag_i->len;
+	}
+
+	return r;
+}

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -35,8 +35,7 @@ enum {
 	SS_OK		= 0,
 };
 
-typedef int (*ss_skb_proc_actor_t)(void *conn, unsigned char *data,
-				   size_t len);
+typedef int (*ss_skb_actor_t)(void *conn, unsigned char *data, size_t len);
 
 int ss_skb_process(struct sk_buff *skb, unsigned int *off,
-		   ss_skb_proc_actor_t proc_actor, void *data);
+		   ss_skb_actor_t actor, void *objdata);

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -1,0 +1,42 @@
+/**
+ *		Tempesta FW
+ *
+ * Synchronous Sockets API for Linux socket buffers manipulation.
+ *
+ * Copyright (C) 2015 Tempesta Technologies, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#include <linux/skbuff.h>
+
+/**
+ * Responses from socket hook functions.
+ */
+enum {
+	/* The packet must be dropped. */
+	SS_DROP		= -2,
+
+	/* The packet should be stashed (made by callback). */
+	SS_POSTPONE	= -1,
+
+	/* The packet looks good and we can safely pass it. */
+	SS_OK		= 0,
+};
+
+typedef int (*ss_skb_proc_actor_t)(void *conn, unsigned char *data,
+				   size_t len);
+
+int ss_skb_process(struct sk_buff *skb, unsigned int *off,
+		   ss_skb_proc_actor_t proc_actor, void *data);

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -25,6 +25,8 @@
 #include <net/sock.h>
 #include <linux/skbuff.h>
 
+#include "ss_skb.h"
+
 /*
  * ------------------------------------------------------------------------
  * 		Socket buffers management
@@ -138,20 +140,6 @@ ss_skb_dequeue(SsSkbList *list)
  * 		Synchronous Sockets API
  * ------------------------------------------------------------------------
  */
-/**
- * Responses from socket hook functions.
- */
-enum {
-	/* The packet must be dropped. */
-	SS_DROP		= -2,
-
-	/* The packet should be stashed (made by callback). */
-	SS_POSTPONE	= -1,
-
-	/* The packet looks good and we can safely pass it. */
-	SS_OK		= 0,
-};
-
 /* Protocol descriptor. */
 typedef struct ss_proto_t {
 	const struct ss_hooks	*hooks;
@@ -171,8 +159,8 @@ typedef struct ss_hooks {
 	int (*connection_error)(struct sock *sk);
 
 	/* Process data received on the socket. */
-	int (*connection_recv)(struct sock *sk, unsigned char *data,
-			       size_t len);
+	int (*connection_recv)(struct sock *sk, struct sk_buff *skb,
+			       unsigned int off);
 
 	/*
 	 * Add the @skb to the current connection message.

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -161,16 +161,6 @@ typedef struct ss_hooks {
 	/* Process data received on the socket. */
 	int (*connection_recv)(struct sock *sk, struct sk_buff *skb,
 			       unsigned int off);
-
-	/*
-	 * Add the @skb to the current connection message.
-	 * We need this low-level sk_buff opertation at connection (higher)
-	 * level to provide zero-copy with socket buffers reusage.
-	 *
-	 * All the put skbs are owned by the protocol handlers.
-	 * Sync sockets don't free the skbs.
-	 */
-	int (*put_skb_to_msg)(SsProto *proto, struct sk_buff *skb);
 } SsHooks;
 
 static inline void ss_callback_write_lock(struct sock *sk)

--- a/tempesta_fw/tls.c
+++ b/tempesta_fw/tls.c
@@ -28,14 +28,18 @@
  * to avoid copying.
  */
 static int
-tfw_tls_msg_process(void *conn, unsigned char *data, size_t len)
+tfw_tls_msg_process(void *conn, struct sk_buff *skb, unsigned int off)
 {
 	int r = TFW_BLOCK;
 	TfwConnection *c = (TfwConnection *)conn;
 	TfwMsg *msg = (TfwMsg *)c->msg;
 
-	/* TODO switch to HTTP FSM, @data and @len must be decrypted here. */
-	r = tfw_gfsm_move(&msg->state, TFW_HTTPS_FSM_TODO_ISSUE_81, data, len);
+	/*
+	 * TODO switch to HTTP FSM, @data and @len must be decrypted here.
+	 * Typically we don't need original skb any more either for server or
+	 * proxy modes, so it has sense to do decryption in-place.
+	 */
+	r = tfw_gfsm_move(&msg->state, TFW_HTTPS_FSM_TODO_ISSUE_81, skb, off);
 
 	return r;
 }


### PR DESCRIPTION
- Rework `tfw_http_req_process() and tfw_http_resp_process()` to use the new architecture;
- Carefully release requests and responses where necessary;
- Keep pairing of responses to corresponding requests correct (#115);
- Do not close server connections unless there's no choice;
- Make code and variable names of the new architecture more uniform and better conforming to the coding style;
- Add numerous comments, and fix old comments for better clarity.