### PR TITLE
Use actual current HTTP message body length in Frang (#146)

### DIFF
--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -186,7 +186,6 @@ typedef struct {
 	unsigned int		hdr_rawid;
 	unsigned long		tm_header;
 	unsigned long		tm_bchunk;
-	unsigned long		body_len;
 	unsigned long		hash;
 } TfwHttpReq;
 

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -174,7 +174,6 @@ typedef struct {
  * @hdr_rawid	- id of the latest RAW header that was checked;
  * @tm_header	- time HTTP header started coming;
  * @tm_bchunk	- time previous chunk of HTTP body had come at;
- * @body_len	- current length of the HTTP message body;
  * @hash	- hash value calculated for the request;
  */
 typedef struct {


### PR DESCRIPTION
Current HTTP message body length is accumulated by the parser, so there's
no need to do the same in Frang. Just use the value from the parser. Also,
Frang runs on an SKB now, not on a data chunk from an SKB. Current SKB is
passed as an argument. That makes the code a tad bit simpler.