### PR TITLE
Do not continue processing data if the socket has been closed.

### DIFF
--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -454,6 +454,7 @@ ss_tcp_process_data(struct sock *sk)
 			 * upper layer for processing.
 			 */
 			read_lock(&sk->sk_callback_lock);
+
 			conn = sk->sk_user_data;
 
 			/*
@@ -484,6 +485,7 @@ ss_tcp_process_data(struct sock *sk)
 			r = SS_CALL(connection_recv, conn, skb, off);
 
 			bh_lock_sock_nested(sk);
+
 			read_unlock(&sk->sk_callback_lock);
 
 			/*
@@ -500,7 +502,7 @@ ss_tcp_process_data(struct sock *sk)
 			 * before this function is called which prevents that.
 			 * See tcp_v4_rcv() and __inet_lookup_established().
 			 */
-			if (sk->sk_state != TCP_ESTABLISHED)
+			if (unlikely(sk->sk_state != TCP_ESTABLISHED))
 				return;
 
 			if (r < 0) {


### PR DESCRIPTION
This is related to the fix for issue #61. That fix created a window
in ss_tcp_process_date() when socket is unlocked, so it may be closed
in a parallel thread. If that happens, ss_tcp_process_data() can not
continue as the socket's data is cleared, and skb_queue_walk_safe()
is not safe anymore. Check for that condition, and bail out if that
happens.