### PR TITLE
Split SKBs with pipelined requests into separate SKBs for each request.

### DIFF
--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -440,6 +440,7 @@ ss_tcp_process_data(struct sock *sk)
 		}
 
 		__skb_unlink(skb, &sk->sk_receive_queue);
+		skb_orphan(skb);
 
 		off = tp->copied_seq - TCP_SKB_CB(skb)->seq;
 		if (tcp_hdr(skb)->syn)

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -37,5 +37,6 @@ enum {
 
 typedef int (*ss_skb_actor_t)(void *conn, unsigned char *data, size_t len);
 
+struct sk_buff *ss_skb_split(struct sk_buff *skb, int len);
 int ss_skb_process(struct sk_buff *skb, unsigned int *off,
 		   ss_skb_actor_t actor, void *objdata);


### PR DESCRIPTION
This commit addresses issues described in #159. SKBs that contain multiple
requests are split into separate SKBs with each SKB containing exactly one
request. In essence, request pipelining is eliminated, and all pipelined
requests are turned into a series of separate requests. The rationale for
that can be found in comments to #159.