### PR TITLE
Remove the case TCP_FIN_WAIT1 state from ss_state_change() (#165)

### DIFF
--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -727,8 +727,7 @@ ss_tcp_state_change(struct sock *sk)
 			assert_spin_locked(&lsk->sk_lock.slock);
 			ss_drain_accept_queue(lsk, sk);
 		}
-	} else if ((sk->sk_state == TCP_CLOSE_WAIT)
-		   || (sk->sk_state == TCP_FIN_WAIT1)) {
+	} else if (sk->sk_state == TCP_CLOSE_WAIT) {
 		/*
 		 * Connection is being closed.
 		 * Either Tempesta sent FIN, or we received FIN.


### PR DESCRIPTION
Socket's state is moved from TCP_ESTABLISHED to TCP_FIN_WAIT_1 when a socket
is actively closed. sk->sk_state_change() is never called when this happens.
So, TCP_FIN_WAIT1 state is completely unnecessary in ss_state_change().