### PR TITLE
fill all output string fields in tfw_http_field_value()

### DIFF
--- a/tempesta_fw/http_sticky.c
+++ b/tempesta_fw/http_sticky.c
@@ -140,6 +140,7 @@ tfw_http_field_value(TfwHttpMsg *hm, const TfwStr *field_name, TfwStr *value)
 	ptr = strim(buf + field_name->len);
 	value->ptr = ptr;
 	value->len = len - (ptr - buf);
+	value->flags = 0;
 
 	return 1;
 }


### PR DESCRIPTION
`tfw_http_field_value()` creates a new dynamically allocated string. So one can expect it to fill all TfwStr fields, including `.flags`.