### PR TITLE
#203. LWS* between name and value and after value for raw headers

### DIFF
--- a/tempesta_fw/http_match.c
+++ b/tempesta_fw/http_match.c
@@ -249,7 +249,6 @@ match_hdr_raw(const TfwHttpReq *req, const TfwHttpMatchRule *rule)
 			ok_code;			\
 		} else {				\
 			err_code;			\
-			BUG();				\
 		}					\
 	}
 
@@ -280,10 +279,14 @@ state_common:
 				c++;
 				prev = *(p - 1);
 			}
-			_TRY_NEXT_CHUNK(goto state_common, return p == pend);
+			_TRY_NEXT_CHUNK(goto state_common, );
 
-			if (p == pend) {
-				return flags & TFW_STR_EQ_PREFIX;
+			if (c == cend && p == pend) {
+				return true;
+			}
+
+			if (p == pend && flags & TFW_STR_EQ_PREFIX) {
+				return true;
 			}
 
 state_sp:

--- a/tempesta_fw/http_match.c
+++ b/tempesta_fw/http_match.c
@@ -465,3 +465,21 @@ tfw_http_match_list_rcu_free(struct rcu_head *r)
 	tfw_pool_free(l->pool);
 }
 EXPORT_SYMBOL(tfw_http_match_list_rcu_free);
+
+void
+tfw_http_match_rule_init(TfwHttpMatchRule *rule, tfw_http_match_fld_t field,
+	tfw_http_match_op_t op, tfw_http_match_arg_t type, const char *arg) {
+	rule->field = field;
+	rule->op = op;
+	rule->arg.type = type;
+	rule->arg.len = strlen(arg);
+	memcpy(rule->arg.str, arg, rule->arg.len + 1);
+
+	if (field == TFW_HTTP_MATCH_F_HDR_RAW) {
+		char *p = rule->arg.str;
+		while ((*p = tolower(*p))) {
+			p++;
+		}
+	}
+}
+EXPORT_SYMBOL(tfw_http_match_rule_init);

--- a/tempesta_fw/http_match.h
+++ b/tempesta_fw/http_match.h
@@ -151,5 +151,7 @@ TfwHttpMatchRule *tfw_http_match_rule_new(TfwHttpMatchList *, size_t arg_len);
 	_c;								\
 })
 
+void tfw_http_match_rule_init(TfwHttpMatchRule *rule, tfw_http_match_fld_t field,
+	tfw_http_match_op_t op, tfw_http_match_arg_t type, const char *arg);
 
 #endif /* __TFW_HTTP_MATCH_H__ */

--- a/tempesta_fw/sched/tfw_sched_http.c
+++ b/tempesta_fw/sched/tfw_sched_http.c
@@ -74,6 +74,7 @@
  */
 
 #include <linux/string.h>
+#include <linux/ctype.h>
 
 #include "cfg.h"
 #include "http_match.h"
@@ -243,6 +244,7 @@ tfw_sched_http_cfg_handle_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 	tfw_http_match_fld_t field;
 	TfwSrvGroup *main_sg, *backup_sg;
 	const char *in_main_sg, *in_field, *in_op, *in_arg, *in_backup_sg;
+	char *p;
 
 	r = tfw_cfg_check_val_n(e, 4);
 	if (r)
@@ -301,6 +303,13 @@ tfw_sched_http_cfg_handle_match(TfwCfgSpec *cs, TfwCfgEntry *e)
 	rule->rule.arg.len = arg_len - 1;
 	memcpy(rule->rule.arg.str, in_arg, arg_len);
 	rule->rule.arg.type = tfw_sched_http_cfg_arg_tbl[field];
+
+	if (rule->rule.field == TFW_HTTP_MATCH_F_HDR_RAW) {
+		p = rule->rule.arg.str;
+		while ((*p = tolower(*p))) {
+			p++;
+		}
+	}
 
 	return 0;
 }

--- a/tempesta_fw/t/unit/test_http_match.c
+++ b/tempesta_fw/t/unit/test_http_match.c
@@ -54,27 +54,15 @@ http_match_suite_teardown(void)
 }
 
 static void
-test_mlst_add(int test_id, tfw_http_match_fld_t req_field,
-              tfw_http_match_op_t op, const char *str_arg)
+test_mlst_add(int test_id, tfw_http_match_fld_t field,
+              tfw_http_match_op_t op, const char *arg)
 {
 	MatchEntry *e;
-	size_t len = strlen(str_arg);
-	char *p;
+	size_t arg_size = strlen(arg) + 1;
 
-	e = tfw_http_match_entry_new(test_mlst, MatchEntry, rule, len);
+	e = tfw_http_match_entry_new(test_mlst, MatchEntry, rule, arg_size);
+	tfw_http_match_rule_init(&e->rule, field, op, TFW_HTTP_MATCH_A_STR, arg);
 	e->test_id = test_id;
-	e->rule.field = req_field;
-	e->rule.op = op;
-	e->rule.arg.type = TFW_HTTP_MATCH_A_STR;
-	e->rule.arg.len = len;
-	memcpy(e->rule.arg.str, str_arg, len);
-
-	if (e->rule.field == TFW_HTTP_MATCH_F_HDR_RAW) {
-		p = e->rule.arg.str;
-		while ((*p = tolower(*p))) {
-			p++;
-		}
-	}
 }
 
 int

--- a/tempesta_fw/t/unit/test_http_match.c
+++ b/tempesta_fw/t/unit/test_http_match.c
@@ -18,6 +18,8 @@
  * this program; if not, write to the Free Software Foundation, Inc., 59
  * Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
+#include <linux/ctype.h>
+
 #include "http_match.h"
 #include "http_msg.h"
 
@@ -57,6 +59,7 @@ test_mlst_add(int test_id, tfw_http_match_fld_t req_field,
 {
 	MatchEntry *e;
 	size_t len = strlen(str_arg);
+	char *p;
 
 	e = tfw_http_match_entry_new(test_mlst, MatchEntry, rule, len);
 	e->test_id = test_id;
@@ -65,6 +68,13 @@ test_mlst_add(int test_id, tfw_http_match_fld_t req_field,
 	e->rule.arg.type = TFW_HTTP_MATCH_A_STR;
 	e->rule.arg.len = len;
 	memcpy(e->rule.arg.str, str_arg, len);
+
+	if (e->rule.field == TFW_HTTP_MATCH_F_HDR_RAW) {
+		p = e->rule.arg.str;
+		while ((*p = tolower(*p))) {
+			p++;
+		}
+	}
 }
 
 int


### PR DESCRIPTION
In accordance with 3.2 RFC 7230 header value can contain groups of whitespace characters. We consider them the equivalent of a single whitespace character, if there is whitespace character / characters in the rule in the same position. For unification, also work with the keys, although whitespace characters are not permitted in the key.