### PR TITLE
Synchronize access to conn->msg_queue. (#184)

### DIFF
--- a/tempesta_fw/connection.c
+++ b/tempesta_fw/connection.c
@@ -50,6 +50,7 @@ tfw_connection_init(TfwConnection *conn)
 
 	INIT_LIST_HEAD(&conn->list);
 	INIT_LIST_HEAD(&conn->msg_queue);
+	spin_lock_init(&conn->msg_qlock);
 }
 
 /*

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -56,6 +56,7 @@ enum {
  * @proto	- protocol handler. Base class, must be first;
  * @list	- list of connections with the @peer;
  * @msg_queue	- messages queue to be sent over the connection;
+ * @msg_qlock	- lock for accessing @msg_queue;
  * @msg		- currently processing (receiving) message;
  * @peer	- TfwClient or TfwServer handler;
  * @sk		- appropriate sock handler;
@@ -64,6 +65,7 @@ typedef struct {
 	SsProto			proto;
 	struct list_head	list;
 	struct list_head	msg_queue;
+	spinlock_t		msg_qlock;
 
 	TfwMsg			*msg;
 	TfwPeer 		*peer;


### PR DESCRIPTION
conn->msg_queue is used for keeping requests until paired responses
are received. Requests are inserted into it as frequently as they
are removed from it, so a plain spinlock is used.