### PR TITLE
Fix the counting of the number of concurrent connections. (#265)

### DIFF
--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -102,14 +102,14 @@ tfw_sock_clnt_new(struct sock *sk)
 	if (!cli) {
 		TFW_ERR("can't obtain a client for the new socket\n");
 		r = -ENOENT;
-		goto err_cli_obtain;
+		goto err_classify;
 	}
 
 	conn = tfw_cli_conn_alloc();
 	if (!conn) {
 		TFW_ERR("can't allocate a new client connection\n");
 		r = -ENOMEM;
-		goto err_conn_alloc;
+		goto err_client;
 	}
 
 	ss_proto_inherit(listen_sock_proto, &conn->proto, Conn_Clnt);
@@ -120,23 +120,22 @@ tfw_sock_clnt_new(struct sock *sk)
 	r = tfw_connection_new(conn);
 	if (r) {
 		TFW_ERR("conn_init() hook returned error\n");
-		goto err_conn_init;
+		goto err_conn;
 	}
 
 	TFW_DBG("new client socket is accepted: sk=%p, conn=%p, cli=%p\n",
 		sk, conn, cli);
 	return 0;
 
-err_conn_init:
+err_conn:
 	tfw_connection_unlink_peer(conn);
 	tfw_connection_unlink_sk(conn);
 	tfw_connection_destruct(conn);
 	tfw_cli_conn_free(conn);
-err_conn_alloc:
+err_client:
 	tfw_client_put(cli);
-err_cli_obtain:
-	tfw_classify_conn_close(sk);
 err_classify:
+	tfw_classify_conn_close(sk);
 	return r;
 }
 


### PR DESCRIPTION
The number of concurrent connections is maintained by classifier that
is called when a connection is established or closed. The number is
inremented when new connection is established. If the limit has been
exceeded on the number, the request is blocked by classifier. It's
expected that the connection is closed when that happens. Classifier
is called again on connection close event, and that's when the number
of concurrent connections is decremented. However, the connection for
the client is not initialized at the time classifier is called. That
lead to the connection drop hook not being called from Sync Sockets,
and therefore classifier was not called on connection close event.
This fix makes sure that classifier is called with connection drop
event when new connection is blocked by classifier.