### PR TITLE
Process data SKB in ss_tcp_state_change() when FIN is received. (#282)

### DIFF
--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -718,7 +718,6 @@ ss_tcp_data_ready(struct sock *sk, int bytes)
 			 * SKBs linked with the currently processed message.
 			 */
 			ss_droplink(sk);
-		}
 	}
 	else {
 		/*
@@ -780,6 +779,11 @@ ss_tcp_state_change(struct sock *sk)
 		/*
 		 * Connection is being closed.
 		 * Either Tempesta sent FIN, or we received FIN.
+		 *
+		 * It may happen that FIN comes with a data SKB. In that
+		 * case this function is called before ss_tcp_data_ready()
+		 * is called. However the SKB needs to be processed before
+		 * the connection is closed.
 		 */
 		if (!skb_queue_empty(&sk->sk_receive_queue))
 			ss_tcp_process_data(sk);

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -469,7 +469,7 @@ ss_droplink(struct sock *sk)
  * TODO:
  * -- process URG
  */
-static int
+static bool
 ss_tcp_process_data(struct sock *sk)
 {
 	bool tcp_fin, droplink = true;
@@ -567,7 +567,7 @@ ss_tcp_process_data(struct sock *sk)
 			 * See tcp_v4_rcv() and __inet_lookup_established().
 			 */
 			if (unlikely(sk->sk_state != TCP_ESTABLISHED))
-				return 0;
+				return false;
 
 			if (r < 0) {
 				SS_WARN("can't process app data on socket %p\n",

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -469,7 +469,7 @@ ss_droplink(struct sock *sk)
  * TODO:
  * -- process URG
  */
-static void
+static int
 ss_tcp_process_data(struct sock *sk)
 {
 	bool tcp_fin, droplink = true;
@@ -567,7 +567,7 @@ ss_tcp_process_data(struct sock *sk)
 			 * See tcp_v4_rcv() and __inet_lookup_established().
 			 */
 			if (unlikely(sk->sk_state != TCP_ESTABLISHED))
-				return;
+				return 0;
 
 			if (r < 0) {
 				SS_WARN("can't process app data on socket %p\n",
@@ -613,17 +613,8 @@ out:
 	tcp_rcv_space_adjust(sk);
 	if (processed)
 		tcp_cleanup_rbuf(sk, processed);
-	if (droplink) {
-		/*
-		 * Drop connection on internal errors as well as
-		 * on banned packets.
-		 *
-		 * ss_droplink() is responsible for calling application
-		 * layer connection closing callback that will free all
-		 * SKBs linked with the currently processed message.
-		 */
-		ss_droplink(sk);
-	}
+
+	return droplink;
 }
 
 /**
@@ -717,7 +708,17 @@ ss_tcp_data_ready(struct sock *sk, int bytes)
 		SS_ERR("error data on socket %p\n", sk);
 	}
 	else if (!skb_queue_empty(&sk->sk_receive_queue)) {
-		ss_tcp_process_data(sk);
+		if (ss_tcp_process_data(sk))
+			/*
+			 * Drop connection in case of FIN, internal errors,
+			 * or banned packets.
+			 *
+			 * ss_droplink() is responsible for calling application
+			 * layer connection closing callback that will free all
+			 * SKBs linked with the currently processed message.
+			 */
+			ss_droplink(sk);
+		}
 	}
 	else {
 		/*
@@ -780,6 +781,8 @@ ss_tcp_state_change(struct sock *sk)
 		 * Connection is being closed.
 		 * Either Tempesta sent FIN, or we received FIN.
 		 */
+		if (!skb_queue_empty(&sk->sk_receive_queue))
+			ss_tcp_process_data(sk);
 		SS_DBG("Peer connection closing\n");
 		ss_droplink(sk);
 	} else if (sk->sk_state == TCP_CLOSE) {


### PR DESCRIPTION
When data SKB is received with FIN flag, sk_state_change() handler
is called first by the kernel. The usual reaction to that is to drop
the connection, close the socket, and start the failover procedure.
However, data SKB has not been processed in that case which lead to
loss of an HTTP message that could not complete. This patch makes
sure the outstanding SKBs are processed before the connection is
dropped and failover procedure started.