### PR TITLE
store chunk size in TfwPoolChunk at creation time

### DIFF
--- a/tempesta_fw/pool.c
+++ b/tempesta_fw/pool.c
@@ -130,8 +130,8 @@ tfw_pool_alloc(TfwPool *p, size_t n)
 		if (!c)
 			return NULL;
 		c->next = curr;
+		c->order = order;
 
-		curr->order = p->order;
 		curr->off = p->off;
 
 		p->order = order;


### PR DESCRIPTION
`c->order` was kept uninitialized, and only filled at next segment allocation time.