### PR TITLE
It's all about tfw_str_to_cstr() 

### DIFF
--- a/tempesta_fw/http_sticky.c
+++ b/tempesta_fw/http_sticky.c
@@ -128,10 +128,7 @@ tfw_http_field_value(TfwHttpMsg *hm, const TfwStr *field_name, TfwStr *value)
 		return 1;
 	}
 
-	/*
-	 * XXX Linearize TfwStr{}. Should be eliminated
-	 * when better TfwStr{} functions are implemented.
-	 */
+	/* field consists of multiple chunks */
 	len = hdr_field->len + 1;
 	if ((buf = tfw_pool_alloc(hm->pool, len)) == NULL) {
 		return -ENOMEM;

--- a/tempesta_fw/http_sticky.c
+++ b/tempesta_fw/http_sticky.c
@@ -110,6 +110,24 @@ tfw_http_field_value(TfwHttpMsg *hm, const TfwStr *field_name, TfwStr *value)
 	if (hdr_field == NULL) {
 		return 0;
 	}
+
+	if (TFW_STR_PLAIN(hdr_field)) {
+		buf = (char *)hdr_field->ptr + field_name->len;
+		len = hdr_field->len - field_name->len;
+
+		while (len > 0 && isspace(*buf)) {
+			buf++;
+			len--;
+		}
+		while (len > 0 && isspace(*(buf + len - 1)))
+			len--;
+
+		value->ptr = buf;
+		value->len = len;
+		value->flags = hdr_field->flags;
+		return 1;
+	}
+
 	/*
 	 * XXX Linearize TfwStr{}. Should be eliminated
 	 * when better TfwStr{} functions are implemented.

--- a/tempesta_fw/str.c
+++ b/tempesta_fw/str.c
@@ -346,7 +346,8 @@ tfw_str_eq_cstr(const TfwStr *str, const char *cstr, int cstr_len,
 EXPORT_SYMBOL(tfw_str_eq_cstr);
 
 /**
- * DEPRECATED: The function intentionaly brokes zero-copy string design.
+ * The function intentionaly brokes zero-copy string design. And should
+ * be used for short-strings only.
  *
  * Join all chunks of @str to a single plain C string.
  *
@@ -354,6 +355,12 @@ EXPORT_SYMBOL(tfw_str_eq_cstr);
  * If the buffer has not enough space to fit all chunks, then the output string
  * is cropped (at most @buf_size - 1 bytes is written). The output string is
  * always terminated with '\0'.
+ *
+ * Caveat: Be sure to free memory block as soon as possible. Leaving it
+ * allocated could ruin successful tfw_pool_realloc() sequence, and cause
+ * excessive copying. Since TfwPool is using stack-like approach, it's
+ * possible to allocate temporary storage for tfw_str_to_cstr() result,
+ * then free it, and successfully continue tfw_pool_realloc() sequence.
  *
  * Returns length of the output string.
  *


### PR DESCRIPTION
* document allocator related concerns;
* avoid calling `tfw_str_to_cstr()` in http sticky cookie code.