### PR TITLE
Item #151, #326 fixing

### DIFF
--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -77,13 +77,6 @@ enum {
 	TFW_HTTP_FSM_DONE	= TFW_GFSM_HTTP_STATE(TFW_GFSM_STATE_LAST)
 };
 
-/**
- * All helping information for current HTTP parsing state of a message.
- */
-#define TFW_HTTP_PF_CR			0x01
-#define TFW_HTTP_PF_LF			0x02
-#define TFW_HTTP_PF_CRLF		(TFW_HTTP_PF_CR | TFW_HTTP_PF_LF)
-
 typedef enum {
 	TFW_HTTP_METH_NONE,
 	TFW_HTTP_METH_GET,
@@ -119,22 +112,24 @@ typedef struct {
  * (e.g. process LWS using @state while current state is saved in @_i_st
  * or using @_i_st parse value of a header described.
  *
- * @state	- current parser state;
- * @_i_st	- helping (interior) state;
  * @to_go	- remaining number of bytes to process in the data chunk;
  *		  (limited by single packet size and never exceeds 64KB)
+ * @state	- current parser state;
+ * @_i_st	- helping (interior) state;
  * @to_read	- remaining number of bytes to read;
+ * @_hdr_tag	- describes, which header should be closed in case of
+ *		  the empty header (see RGEN_LWS_empty)
  * @_tmp_acc	- integer accumulator for parsing chunked integers;
  * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
  * @hdr		- currently parsed header.
  */
 typedef struct tfw_http_parser {
-	unsigned char	flags;
 	unsigned short	to_go;
 	int		state;
 	int		_i_st;
 	int		to_read;
 	unsigned long	_tmp_acc;
+	unsigned int	_hdr_tag;
 	TfwStr		_tmp_chunk;
 	TfwStr		hdr;
 } TfwHttpParser;
@@ -186,6 +181,8 @@ typedef struct {
 /* Request flags */
 #define TFW_HTTP_STICKY_SET		0x0100	/* Need 'Set-Cookie` */
 #define TFW_HTTP_FIELD_DUPENTRY		0x0200	/* Duplicate field */
+/* URI has form http://authority/path, not just /path */
+#define TFW_HTTP_URI_FULL		0x0400
 
 /**
  * Common HTTP message members.

--- a/tempesta_fw/http_msg.h
+++ b/tempesta_fw/http_msg.h
@@ -37,7 +37,7 @@ tfw_http_msg_set_data(TfwHttpMsg *hm, TfwStr *str, void *data)
 	str->skb = ss_skb_peek_tail(&hm->msg.skb_list);
 }
 
-void tfw_http_msg_hdr_val(TfwStr *hdr, int id, TfwStr *val);
+void tfw_http_msg_hdr_val(TfwStr *hdr, unsigned id, TfwStr *val);
 
 int tfw_http_msg_add_data_ptr(TfwHttpMsg *hm, TfwStr *str, void *data,
 			      size_t len);


### PR DESCRIPTION
check if Host: == host in URI

Handle empty Host: header

remove unused vars

fix variables names

use hardware crc32 only if supported