### PR TITLE
Fix #192: zero-copy tfw_addr_pton

### DIFF
--- a/tempesta_fw/addr.h
+++ b/tempesta_fw/addr.h
@@ -23,6 +23,7 @@
 
 #include <net/inet_sock.h>
 #include <net/ipv6.h>
+#include "str.h"
 
 /**
  * The default port for textual IP address representations.
@@ -43,7 +44,7 @@ typedef union {
 } TfwAddr;
 
 bool tfw_addr_eq(const TfwAddr *addr1, const TfwAddr *addr2);
-int tfw_addr_pton(const char *str, TfwAddr *addr);
+int tfw_addr_pton(const TfwStr *str, TfwAddr *addr);
 size_t tfw_addr_ntop(const TfwAddr *addr, char *out_buf, size_t buf_size);
 
 /* A couple of lower-level functions faster than tfw_addr_ntop().

--- a/tempesta_fw/classifier/frang.c
+++ b/tempesta_fw/classifier/frang.c
@@ -464,8 +464,6 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 {
 	TfwAddr addr;
 	TfwStr field;
-	char *buf;
-	int len;
 
 	if (TFW_STR_EMPTY(&req->h_tbl->tbl[TFW_HTTP_HDR_HOST])) {
 		frang_msg("Host header field", &ra->addr, " is missed\n");
@@ -482,17 +480,11 @@ frang_http_host_check(const TfwHttpReq *req, FrangAcc *ra)
 	 * have a good regex library.
 	 * For now just linearize the Host header field TfwStr{} string.
 	 */
-	len = field.len + 1;
-	if ((buf = tfw_pool_alloc(req->pool, len)) == NULL)
-		return TFW_BLOCK;
-	tfw_str_to_cstr(&field, buf, len);
-	if (!tfw_addr_pton(buf, &addr)) {
+	if (!tfw_addr_pton(&field, &addr)) {
 		frang_msg("Host header field contains IP address",
 			  &ra->addr, "\n");
-		tfw_pool_free(req->pool, buf, len);
 		return TFW_BLOCK;
 	}
-	tfw_pool_free(req->pool, buf, len);
 	return TFW_PASS;
 }
 

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -382,7 +382,7 @@ tfw_sock_clnt_cfg_handle_listen(TfwCfgSpec *cs, TfwCfgEntry *ce)
 		addr.v4.sin_addr.s_addr = INADDR_ANY;
 		addr.v4.sin_port = htons(port);
 	} else {
-		r = tfw_addr_pton(in_str, &addr);
+		r = tfw_addr_pton(&TFW_STR_FROM(in_str), &addr);
 		if (r)
 			goto parse_err;
 	}

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -543,7 +543,7 @@ tfw_srv_cfg_handle_server(TfwCfgSpec *cs, TfwCfgEntry *ce)
 	in_addr = ce->vals[0];
 	in_conns_n = tfw_cfg_get_attr(ce, "conns_n", TFW_SRV_CFG_DEF_CONNS_N);
 
-	r = tfw_addr_pton(in_addr, &addr);
+	r = tfw_addr_pton(&TFW_STR_FROM(in_addr), &addr);
 	if (r)
 		return r;
 	r = tfw_cfg_parse_int(in_conns_n, &conns_n);

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -102,6 +102,7 @@ typedef struct {
 
 #define DEFINE_TFW_STR(name, val) TfwStr name = { (val), NULL,		\
 						  sizeof(val) - 1, 0 }
+#define TFW_STR_FROM(s)         ((TfwStr){(char*)s, NULL, strlen(s)})
 
 /* Numner of chunks in @s. */
 #define TFW_STR_CHUNKN(s)	((s)->flags >> TFW_STR_CN_SHIFT)
@@ -131,7 +132,7 @@ typedef struct {
  */
 #define TFW_STR_CURR(s)							\
 ({									\
-	TfwStr *_tmp = TFW_STR_DUP(s)					\
+	typeof(s) _tmp = TFW_STR_DUP(s)					\
 		       ? (TfwStr *)(s)->ptr + TFW_STR_CHUNKN(s) - 1	\
 		       : (s);						\
 	(_tmp->flags & __TFW_STR_COMPOUND)				\

--- a/tempesta_fw/t/unit/sched_helper.c
+++ b/tempesta_fw/t/unit/sched_helper.c
@@ -83,7 +83,7 @@ test_create_srv(const char *in_addr, TfwSrvGroup *sg)
 	TfwServer *srv;
 
 	{
-		int r = tfw_addr_pton(in_addr, &addr);
+		int r = tfw_addr_pton(&TFW_STR_FROM(in_addr), &addr);
 		BUG_ON(r);
 	}
 

--- a/tempesta_fw/t/unit/test_addr.c
+++ b/tempesta_fw/t/unit/test_addr.c
@@ -143,11 +143,11 @@ TEST(tfw_addr_ntop, omits_port_80)
 
 TEST(tfw_addr_pton, recognizes_v4_and_v6_addrs)
 {
-        const char *s1 = "127.0.0.1";
-        const char *s2 = "127.0.0.1:8081";
-        const char *s3 = "1111::2:a:B";
-        const char *s4 = "[::1]:1234";
-        const char *s5 = "[::0]:5678";
+        DEFINE_TFW_STR(s1, "127.0.0.1");
+        DEFINE_TFW_STR(s2, "127.0.0.1:8081");
+        DEFINE_TFW_STR(s3, "1111::2:a:B");
+        DEFINE_TFW_STR(s4, "[::1]:1234");
+        DEFINE_TFW_STR(s5, "[::0]:5678");
 
         TfwAddr e1 = {
                 .v4.sin_family = AF_INET,
@@ -180,11 +180,11 @@ TEST(tfw_addr_pton, recognizes_v4_and_v6_addrs)
         TfwAddr a1, a2, a3, a4, a5;
         int r1, r2, r3, r4, r5;
 
-        r1 = tfw_addr_pton(s1, &a1);
-        r2 = tfw_addr_pton(s2, &a2);
-        r3 = tfw_addr_pton(s3, &a3);
-        r4 = tfw_addr_pton(s4, &a4);
-        r5 = tfw_addr_pton(s5, &a5);
+        r1 = tfw_addr_pton(&s1, &a1);
+        r2 = tfw_addr_pton(&s2, &a2);
+        r3 = tfw_addr_pton(&s3, &a3);
+        r4 = tfw_addr_pton(&s4, &a4);
+        r5 = tfw_addr_pton(&s5, &a5);
 
         EXPECT_OK(r1);
         EXPECT_OK(r2);


### PR DESCRIPTION
#192
Iterating over C-string is replaced with iterating over TfwStr.