### PR TITLE
Close client connections when requested by clients. (#348)

### DIFF
--- a/tempesta_fw/client.h
+++ b/tempesta_fw/client.h
@@ -45,6 +45,7 @@ typedef struct {
 TfwClient *tfw_client_obtain(struct sock *sk);
 void tfw_client_put(TfwClient *cli);
 void tfw_cli_conn_release(TfwConnection *conn);
+int tfw_sock_clnt_drop(struct sock *sk);
 int tfw_sock_check_listeners(void);
 
 #endif /* __TFW_CLIENT_H__ */

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -209,23 +209,6 @@ tfw_connection_live(TfwConnection *conn)
 	return conn->sk && ss_sock_live(conn->sk);
 }
 
-/*
- * Drop a connection. This function may be called only when there's
- * at least one extra reference to the connection (@conn->refcnt),
- * so if the reference is dropped here it's never the last one.
- * See comments to ss_do_droplink() and ss_droplink().
- *
- * Note: Don't put a BUG_ON() on @conn->refcnt in this function to
- * enforce the condition mentioned above. That may lead to a race
- * condition with ss_tcp_process_data(). If this function is called
- * under wrong conditions, the check may also be invalid.
- */
-static inline void
-tfw_connection_drop(TfwConnection *conn)
-{
-	ss_droplink(conn->sk);
-}
-
 /**
  * Check that TfwConnection resources are cleaned up properly.
  */

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -209,6 +209,17 @@ tfw_connection_live(TfwConnection *conn)
 	return conn->sk && ss_sock_live(conn->sk);
 }
 
+/*
+ * Drop a connection. This function may be called only when there's
+ * at least one extra reference to the connection (@conn->refcnt),
+ * so if the reference is dropped here it's never the last one.
+ * See comments to ss_do_droplink() and ss_droplink().
+ *
+ * Note: Don't put a BUG_ON() on @conn->refcnt in this function to
+ * enforce the condition mentioned above. That may lead to a race
+ * condition with ss_tcp_process_data(). If this function is called
+ * under wrong conditions, the check may also be invalid.
+ */
 static inline void
 tfw_connection_drop(TfwConnection *conn)
 {

--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -209,6 +209,12 @@ tfw_connection_live(TfwConnection *conn)
 	return conn->sk && ss_sock_live(conn->sk);
 }
 
+static inline void
+tfw_connection_drop(TfwConnection *conn)
+{
+	ss_droplink(conn->sk);
+}
+
 /**
  * Check that TfwConnection resources are cleaned up properly.
  */

--- a/tempesta_fw/gfsm.h
+++ b/tempesta_fw/gfsm.h
@@ -109,6 +109,12 @@ enum {
  */
 enum {
 	/*
+	 * Stop passing data for processing from the lower layer.
+	 * Incoming data packets must be dropped.
+	 */
+	TFW_STOP	= SS_STOP,
+
+	/*
 	 * Current message looks good and we can safely pass it.
 	 */
 	TFW_PASS	= SS_OK,

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -379,8 +379,8 @@ tfw_http_conn_msg_free(TfwHttpMsg *hm)
  * See the comment to ss_close().
  *
  * The connection may be dropped only by the party that closed the
- * socket. It's essential that the connection is dropped only when
- * there's at least one extra reference to it (@conn->refcnt).
+ * socket. Also, it's essential that the connection is dropped only
+ * when there's at least one extra reference to it (@conn->refcnt).
  * Then if the reference is dropped here it's never the last one.
  * That won't allow Sync Sockets to destroy the socket and the
  * connection completely until Tempesta is done with the connection.
@@ -393,7 +393,7 @@ tfw_http_conn_cli_dropfree(TfwHttpMsg *hmreq)
 	BUG_ON(!(TFW_CONN_TYPE(hmreq->conn) & Conn_Clnt));
 
 	if (hmreq->flags & TFW_HTTP_CONN_CLOSE) {
-		if (ss_close(hmreq->conn->sk) == 0)
+		if (ss_close(hmreq->conn->sk) == SS_OK)
 			tfw_sock_clnt_drop(hmreq->conn->sk);
 	}
 	tfw_http_conn_msg_free(hmreq);

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -291,7 +291,6 @@ int tfw_http_parse_req(void *req_data, unsigned char *data, size_t len);
 int tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len);
 
 /* External HTTP functions. */
-void tfw_http_conn_msg_free(TfwHttpMsg *hm);
 int tfw_http_msg_process(void *conn, struct sk_buff *skb, unsigned int off);
 unsigned long tfw_http_req_key_calc(TfwHttpReq *req);
 

--- a/tempesta_fw/server.h
+++ b/tempesta_fw/server.h
@@ -88,6 +88,7 @@ tfw_server_offline(TfwServer *srv)
 }
 
 void tfw_srv_conn_release(TfwConnection *conn);
+int tfw_sock_srv_drop(struct sock *sk);
 
 /* Server group routines. */
 TfwSrvGroup *tfw_sg_lookup(const char *name);

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -441,12 +441,12 @@ ss_do_close(struct sock *sk)
 /*
  * Close a socket.
  *
- * This function is for use by other Tempesta components. It may be
- * called either in the context of the socket that is being closed,
- * or in the context of a completely different socket.
+ * This function is for use by other Tempesta components. It may
+ * be called either in the context of the socket that is being
+ * closed, or in the context of a completely different socket.
  *
- * This function may be used in process and SoftIRQ contexts. Must
- * be called with BH disabled in process context.
+ * This function may be used in process and SoftIRQ contexts.
+ * Must be called with BH disabled in process context.
  *
  * This function may be executed concurrently with ss_do_close()
  * that is triggered by an incoming FIN. Only one of the two must
@@ -461,8 +461,8 @@ ss_do_close(struct sock *sk)
  *   the socket is not live and does not execute the body again.
  *
  * @return:
- *   0 - the socket is closed in this call.
- *   1 - the socket is closed or is being closed by someone else.
+ *   SS_OK - the socket is closed in this call.
+ *   SS_POSTPONE - the socket is (being) closed by someone else.
  */
 int
 ss_close(struct sock *sk)
@@ -778,7 +778,7 @@ ss_tcp_data_ready(struct sock *sk)
 }
 
 /**
- * Socket state change callback. Called from tcp_rcv_state_process().
+ * Socket state change callback.
  */
 static void
 ss_tcp_state_change(struct sock *sk)

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -471,13 +471,13 @@ ss_close(struct sock *sk)
 	if (!ss_sock_live(sk)) {
 		bh_unlock_sock(sk);
 		SS_DBG("%s: Socket inactive: sk %p\n", __func__, sk);
-		return 1;
+		return SS_POSTPONE;
 	}
 	__ss_do_close(sk);
 	bh_unlock_sock(sk);
 
 	sock_put(sk);
-	return 0;
+	return SS_OK;
 }
 EXPORT_SYMBOL(ss_close);
 

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -144,7 +144,7 @@ err_client:
 	return r;
 }
 
-static int
+int
 tfw_sock_clnt_drop(struct sock *sk)
 {
 	TfwConnection *conn = rcu_dereference_sk_user_data(sk);

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -329,6 +329,16 @@ tfw_sock_srv_connect_retry(struct sock *sk)
 	return tfw_sock_srv_do_failover(sk, "connection error");
 }
 
+/*
+ * This function is called when a server connection is explicitly dropped
+ * by Tempesta.
+ */
+int
+tfw_sock_srv_drop(struct sock *sk)
+{
+	return tfw_sock_srv_do_failover(sk, "connection dropped");
+}
+
 static const SsHooks tfw_sock_srv_ss_hooks = {
 	.connection_new		= tfw_sock_srv_connect_complete,
 	.connection_drop	= tfw_sock_srv_connect_failover,

--- a/tempesta_fw/ss_skb.h
+++ b/tempesta_fw/ss_skb.h
@@ -38,6 +38,9 @@ enum {
 
 	/* The packet looks good and we can safely pass it. */
 	SS_OK		= 0,
+
+	/* Stop passing data to the upper layer for processing. */
+	SS_STOP		= 1,
 };
 
 typedef struct {

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -86,7 +86,7 @@ void ss_proto_inherit(const SsProto *parent, SsProto *child, int child_type);
 void ss_set_callbacks(struct sock *sk);
 void ss_set_listen(struct sock *sk);
 void ss_send(struct sock *sk, SsSkbList *skb_list, bool pass_skb);
-void ss_close(struct sock *sk);
+int ss_close(struct sock *sk);
 int ss_sock_create(int family, int type, int protocol, struct sock **res);
 void ss_release(struct sock *sk);
 int ss_connect(struct sock *sk, struct sockaddr *addr, int addrlen, int flags);

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -69,10 +69,9 @@ ss_sock_live(struct sock *sk)
 }
 
 /*
- * Socket is in a usable state that allows processing and
- * sending of HTTP messages. This must be used consistently
- * across the following functions: ss_tcp_process_data(),
- * ss_send(), ss_do_droplink(), and tfw_http_req_process().
+ * Socket is in a usable state that allows processing
+ * and sending of HTTP messages. This function must
+ * be used consistently across all involved functions.
  * 
  */
 static inline bool ss_sock_active(struct sock *sk)

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -68,8 +68,14 @@ ss_sock_live(struct sock *sk)
 	return sk->sk_state == TCP_ESTABLISHED;
 }
 
-static inline bool
-ss_can_send(struct sock *sk)
+/*
+ * Socket is in a usable state that allows processing and
+ * sending of HTTP messages. This must be used consistently
+ * across the following functions: ss_tcp_process_data(),
+ * ss_send(), ss_do_droplink(), and tfw_http_req_process().
+ * 
+ */
+static inline bool ss_sock_active(struct sock *sk)
 {
 	return (1 << sk->sk_state) & (TCPF_ESTABLISHED | TCPF_CLOSE_WAIT);
 }
@@ -83,6 +89,7 @@ void ss_set_callbacks(struct sock *sk);
 void ss_set_listen(struct sock *sk);
 void ss_send(struct sock *sk, SsSkbList *skb_list, bool pass_skb);
 void ss_close(struct sock *sk);
+void ss_droplink(struct sock *sk);
 int ss_sock_create(int family, int type, int protocol, struct sock **res);
 void ss_release(struct sock *sk);
 int ss_connect(struct sock *sk, struct sockaddr *addr, int addrlen, int flags);

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -72,7 +72,6 @@ ss_sock_live(struct sock *sk)
  * Socket is in a usable state that allows processing
  * and sending of HTTP messages. This function must
  * be used consistently across all involved functions.
- * 
  */
 static inline bool ss_sock_active(struct sock *sk)
 {
@@ -88,7 +87,6 @@ void ss_set_callbacks(struct sock *sk);
 void ss_set_listen(struct sock *sk);
 void ss_send(struct sock *sk, SsSkbList *skb_list, bool pass_skb);
 void ss_close(struct sock *sk);
-void ss_droplink(struct sock *sk);
 int ss_sock_create(int family, int type, int protocol, struct sock **res);
 void ss_release(struct sock *sk);
 int ss_connect(struct sock *sk, struct sockaddr *addr, int addrlen, int flags);

--- a/tempesta_fw/sync_socket.h
+++ b/tempesta_fw/sync_socket.h
@@ -73,7 +73,8 @@ ss_sock_live(struct sock *sk)
  * and sending of HTTP messages. This function must
  * be used consistently across all involved functions.
  */
-static inline bool ss_sock_active(struct sock *sk)
+static inline bool
+ss_sock_active(struct sock *sk)
 {
 	return (1 << sk->sk_state) & (TCPF_ESTABLISHED | TCPF_CLOSE_WAIT);
 }


### PR DESCRIPTION
When "Connection: close" header is present in an HTTP request from a client,
close the connection after the response is sent to that client.