### PR TITLE
Handle responses to HEAD method requests. (#414)

### DIFF
--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -333,8 +333,8 @@ tfw_http_conn_msg_alloc(TfwConnection *conn)
 		TfwHttpReq *req;
 
 		spin_lock(&conn->msg_qlock);
-		req = (TfwHttpReq *)list_first_entry(&conn->msg_queue,
-						     TfwMsg, msg_list);
+		req = (TfwHttpReq *)list_first_entry_or_null(&conn->msg_queue,
+							     TfwMsg, msg_list);
 		spin_unlock(&conn->msg_qlock);
 		if (req && (req->method == TFW_HTTP_METH_HEAD))
 			hm->flags |= TFW_HTTP_VOID_BODY;

--- a/tempesta_fw/http.c
+++ b/tempesta_fw/http.c
@@ -327,10 +327,19 @@ tfw_http_conn_msg_alloc(TfwConnection *conn)
 	tfw_connection_get(conn);
 	tfw_gfsm_state_init(&hm->msg.state, conn, TFW_HTTP_FSM_INIT);
 
-        if (TFW_CONN_TYPE(conn) & Conn_Clnt)
+        if (TFW_CONN_TYPE(conn) & Conn_Clnt) {
                 TFW_INC_STAT_BH(clnt.rx_messages);
-        else
+        } else {
+		TfwHttpReq *req;
+
+		spin_lock(&conn->msg_qlock);
+		req = (TfwHttpReq *)list_first_entry(&conn->msg_queue,
+						     TfwMsg, msg_list);
+		spin_unlock(&conn->msg_qlock);
+		if (req && (req->method == TFW_HTTP_METH_HEAD))
+			hm->flags |= TFW_HTTP_VOID_BODY;
                 TFW_INC_STAT_BH(serv.rx_messages);
+	}
 
 	return (TfwMsg *)hm;
 }

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -185,16 +185,19 @@ typedef struct {
 #define TFW_HHTBL_SZ(o)			TFW_HHTBL_EXACTSZ(__HHTBL_SZ(o))
 
 /* Common flags for requests and responses. */
-#define TFW_HTTP_CONN_CLOSE		0x0001
-#define TFW_HTTP_CONN_KA		0x0002
+#define TFW_HTTP_CONN_CLOSE		0x000001
+#define TFW_HTTP_CONN_KA		0x000002
 #define __TFW_HTTP_CONN_MASK		(TFW_HTTP_CONN_CLOSE | TFW_HTTP_CONN_KA)
-#define TFW_HTTP_CHUNKED		0x0004
+#define TFW_HTTP_CHUNKED		0x000004
 
 /* Request flags */
-#define TFW_HTTP_STICKY_SET		0x0100	/* Need 'Set-Cookie` */
-#define TFW_HTTP_FIELD_DUPENTRY		0x0200	/* Duplicate field */
+#define TFW_HTTP_STICKY_SET		0x000100	/* Need 'Set-Cookie` */
+#define TFW_HTTP_FIELD_DUPENTRY		0x000200	/* Duplicate field */
 /* URI has form http://authority/path, not just /path */
-#define TFW_HTTP_URI_FULL		0x0400
+#define TFW_HTTP_URI_FULL		0x000400
+
+/* Response flags */
+#define TFW_HTTP_VOID_BODY		0x010000	/* Resp to HEAD req */
 
 /**
  * Common HTTP message members.

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -550,7 +550,9 @@ do {									\
 	if (msg->flags & TFW_HTTP_CHUNKED)				\
 		__FSM_B_MOVE(to_state);					\
 	/* Next we check content length. */				\
-	if (msg->content_length) {					\
+	if (msg->content_length						\
+	    && !(msg->flags & TFW_HTTP_VOID_BODY))			\
+	{								\
 		parser->to_read = msg->content_length;			\
 		__FSM_B_MOVE(to_state);					\
 	}								\


### PR DESCRIPTION
According to RFC2616 Section 9.4 the HEAD method is identical to GET
except that the server MUST NOT return a message-body in the response.
However, the parser expects the presense of the body when it sees that
the response header has "Content-Length" header field with specified
body length. This change makes the parser know that the response body
is not present even though the response header indicates that it does.