### PR TITLE
Make sure the pool pointer is valid.

### DIFF
--- a/tempesta_fw/pool.c
+++ b/tempesta_fw/pool.c
@@ -232,6 +232,9 @@ tfw_pool_destroy(TfwPool *p)
 {
 	TfwPoolChunk *c, *next;
 
+	if (!p)
+		return;
+
 	for (c = p->curr; c; c = next) {
 		next = c->next;
 		tfw_pool_free_pages(TFW_POOL_CHUNK_BASE(c), c->order);


### PR DESCRIPTION
There's an execution path where the pool pointer can be NULL. That
happens when an HTTP message structure is allocated statically or
on stack (one of TfwHttpMsg{}, TfwHttpReq{}, or TfwHttpResp{}).