### PR TITLE
Allow only LF and CRLF in while parsing HTTP (v3)

### DIFF
--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -128,7 +128,8 @@ typedef struct {
  * @to_read	- remaining number of bytes to read;
  * @_hdr_tag	- describes, which header should be closed in case of
  *		  the empty header (see RGEN_LWS_empty)
- * @_tmp_acc	- integer accumulator for parsing chunked integers;
+ * @_tmp	- temporary register used to store context-specific data
+ *                  acc) integer accumulator for parsing chunked integers;
  * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
  * @hdr		- currently parsed header.
  */
@@ -137,7 +138,9 @@ typedef struct {
 	int		state;
 	int		_i_st;
 	int		to_read;
-	unsigned long	_tmp_acc;
+	union {
+		unsigned long acc;
+	} _tmp;
 	unsigned int	_hdr_tag;
 	TfwStr		_tmp_chunk;
 	TfwStr		hdr;

--- a/tempesta_fw/http.h
+++ b/tempesta_fw/http.h
@@ -130,6 +130,7 @@ typedef struct {
  *		  the empty header (see RGEN_LWS_empty)
  * @_tmp	- temporary register used to store context-specific data
  *                  acc) integer accumulator for parsing chunked integers;
+ *                  eol) track of CR/LF delimiters while hunting for EOL;
  * @_tmp_chunk	- currently parsed (sub)string, possibly chunked;
  * @hdr		- currently parsed header.
  */
@@ -140,6 +141,7 @@ typedef struct {
 	int		to_read;
 	union {
 		unsigned long acc;
+		unsigned long eol;
 	} _tmp;
 	unsigned int	_hdr_tag;
 	TfwStr		_tmp_chunk;

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -46,6 +46,9 @@ enum {
 	RGen_LWS_empty,
 	RGen_EoL, RGen__EoL,
 	RGen_Hdr,
+	RGen_HdrOther,
+	RGen_HdrOtherN,
+	RGen_HdrOtherV,
 	RGen_Body,
 	RGen_BodyChunkExt,
 	RGen_BodyReadChunk,
@@ -671,18 +674,30 @@ __FSM_STATE(st_curr) {							\
  * TODO Use AVX scan over _allowed_ alphabet.
  * TODO Split the headers to header name and header field as special headers.
  */
-#define TFW_HTTP_PARSE_HDR_OTHER(prefix)				\
-__FSM_STATE(prefix ## _HdrOther) {					\
+#define RGEN_HDR_OTHER()						\
+__FSM_STATE(RGen_HdrOther) {						\
+	parser->_hdr_tag = TFW_HTTP_HDR_RAW;				\
+	/* Fall through */						\
+}									\
+__FSM_STATE(RGen_HdrOtherN) {						\
+	if (likely(IN_ALPHABET(c, hdr_a))) {				\
+		__FSM_MOVE(RGen_HdrOtherN);				\
+	} else if (likely(c == ':')) {					\
+		parser->_i_st = RGen_HdrOtherV;				\
+		__FSM_MOVE(RGen_LWS_empty);				\
+	}								\
+	return TFW_BLOCK;						\
+}									\
+__FSM_STATE(RGen_HdrOtherV) {						\
 	/* Just eat the header until EOL. */				\
 	__fsm_sz = len - (size_t)(p - data);				\
 	__fsm_ch = memchreol(p, __fsm_sz);				\
 	if (__fsm_ch) {							\
 		/* Get length of the header. */				\
 		tfw_http_msg_hdr_chunk_fixup(msg, data, __fsm_ch - data);\
-		parser->_hdr_tag = TFW_HTTP_HDR_RAW;			\
 		__FSM_MOVE_n(RGen_EoL, __fsm_ch - p);			\
 	}								\
-	__FSM_MOVE_n(prefix ## _HdrOther, __fsm_sz);			\
+	__FSM_MOVE_n(RGen_HdrOtherV, __fsm_sz);				\
 }
 
 /*
@@ -1184,7 +1199,6 @@ enum {
 	Req_HdrUser_Agen,
 	Req_HdrUser_Agent,
 	Req_HdrUser_AgentV,
-	Req_HdrOther,
 	/* Body */
 	/* URI normalization. */
 	Req_UriNorm,
@@ -1880,7 +1894,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			}
 			__FSM_MOVE(Req_HdrU);
 		default:
-			__FSM_JMP(Req_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -1923,7 +1937,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			}
 			__FSM_MOVE(Req_HdrCo);
 		default:
-			__FSM_JMP(Req_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -1949,7 +1963,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 			}
 			__FSM_MOVE(Req_HdrContent_T);
 		default:
-			__FSM_JMP(Req_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -1994,7 +2008,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 				     msg, __req_parse_cookie,
 				     TFW_HTTP_HDR_COOKIE, 0);
 
-	TFW_HTTP_PARSE_HDR_OTHER(Req);
+	RGEN_HDR_OTHER();
 
 	/* ----------------    Request body    ---------------- */
 
@@ -2062,18 +2076,18 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 	}
 
 	/* Cache-Control header processing. */
-	__FSM_TX_AF(Req_HdrCa, 'c', Req_HdrCac, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCac, 'h', Req_HdrCach, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCach, 'e', Req_HdrCache, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache, '-', Req_HdrCache_, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_, 'c', Req_HdrCache_C, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_C, 'o', Req_HdrCache_Co, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_Co, 'n', Req_HdrCache_Con, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_Con, 't', Req_HdrCache_Cont, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_Cont, 'r', Req_HdrCache_Contr, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_Contr, 'o', Req_HdrCache_Contro, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCache_Contro, 'l', Req_HdrCache_Control, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrCache_Control, ':', Req_HdrCache_ControlV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrCa, 'c', Req_HdrCac, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCac, 'h', Req_HdrCach, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCach, 'e', Req_HdrCache, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache, '-', Req_HdrCache_, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_, 'c', Req_HdrCache_C, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_C, 'o', Req_HdrCache_Co, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_Co, 'n', Req_HdrCache_Con, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_Con, 't', Req_HdrCache_Cont, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_Cont, 'r', Req_HdrCache_Contr, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_Contr, 'o', Req_HdrCache_Contro, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCache_Contro, 'l', Req_HdrCache_Control, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrCache_Control, ':', Req_HdrCache_ControlV, RGen_HdrOther);
 
 	__FSM_STATE(Req_HdrCo) {
 		switch (LC(c)) {
@@ -2082,7 +2096,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 		case 'o':
 			__FSM_MOVE(Req_HdrCoo);
 		default:
-			__FSM_JMP(Req_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -2094,105 +2108,104 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 		case 't':
 			__FSM_MOVE(Req_HdrCont);
 		default:
-			__FSM_JMP(Req_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
-	__FSM_TX_AF(Req_HdrConn, 'e', Req_HdrConne, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConne, 'c', Req_HdrConnec, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConnec, 't', Req_HdrConnect, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConnect, 'i', Req_HdrConnecti, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConnecti, 'o', Req_HdrConnectio, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConnectio, 'n', Req_HdrConnection, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrConnection, ':', Req_HdrConnectionV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrConn, 'e', Req_HdrConne, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConne, 'c', Req_HdrConnec, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConnec, 't', Req_HdrConnect, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConnect, 'i', Req_HdrConnecti, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConnecti, 'o', Req_HdrConnectio, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConnectio, 'n', Req_HdrConnection, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrConnection, ':', Req_HdrConnectionV, RGen_HdrOther);
 
 	/* Content-* headers processing. */
-	__FSM_TX_AF(Req_HdrCont, 'e', Req_HdrConte, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConte, 'n', Req_HdrConten, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrConten, 't', Req_HdrContent, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent, '-', Req_HdrContent_, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrCont, 'e', Req_HdrConte, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConte, 'n', Req_HdrConten, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrConten, 't', Req_HdrContent, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent, '-', Req_HdrContent_, RGen_HdrOther);
 
 	/* Content-Length header processing. */
-	__FSM_TX_AF(Req_HdrContent_L, 'e', Req_HdrContent_Le, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent_Le, 'n', Req_HdrContent_Len, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent_Len, 'g', Req_HdrContent_Leng, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent_Leng, 't', Req_HdrContent_Lengt, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent_Lengt, 'h', Req_HdrContent_Length, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrContent_Length, ':', Req_HdrContent_LengthV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_L, 'e', Req_HdrContent_Le, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_Le, 'n', Req_HdrContent_Len, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_Len, 'g', Req_HdrContent_Leng, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_Leng, 't', Req_HdrContent_Lengt, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_Lengt, 'h', Req_HdrContent_Length, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrContent_Length, ':', Req_HdrContent_LengthV, RGen_HdrOther);
 
 	/* Content-Type header processing. */
-	__FSM_TX_AF(Req_HdrContent_T, 'y', Req_HdrContent_Ty, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent_Ty, 'p', Req_HdrContent_Typ, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrContent_Typ, 'e', Req_HdrContent_Type, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrContent_Type, ':', Req_HdrContent_TypeV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_T, 'y', Req_HdrContent_Ty, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_Ty, 'p', Req_HdrContent_Typ, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrContent_Typ, 'e', Req_HdrContent_Type, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrContent_Type, ':', Req_HdrContent_TypeV, RGen_HdrOther);
 
 	/* Host header processing. */
-	__FSM_TX_AF(Req_HdrH, 'o', Req_HdrHo, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrHo, 's', Req_HdrHos, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrHos, 't', Req_HdrHost, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrH, 'o', Req_HdrHo, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrHo, 's', Req_HdrHos, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrHos, 't', Req_HdrHost, RGen_HdrOther);
 	/* NOTE: Allow empty host field-value there. RFC 7230 5.4. */
 	__FSM_STATE(Req_HdrHost) {
-		if (likely(tolower(c) == ':')) {
+		if (likely(c == ':')) {
 			parser->_i_st = Req_HdrHostV;
 			__FSM_MOVE(RGen_LWS_empty);
 		}
-		/* It should be checked in Req_HdrOther if `:` is allowed */
-		__FSM_JMP(Req_HdrOther);
+		__FSM_JMP(RGen_HdrOther);
 	}
 
 	/* Transfer-Encoding header processing. */
-	__FSM_TX_AF(Req_HdrT, 'r', Req_HdrTr, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTr, 'a', Req_HdrTra, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTra, 'n', Req_HdrTran, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTran, 's', Req_HdrTrans, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTrans, 'f', Req_HdrTransf, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransf, 'e', Req_HdrTransfe, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfe, 'r', Req_HdrTransfer, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer, '-', Req_HdrTransfer_, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_, 'e', Req_HdrTransfer_E, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_E, 'n', Req_HdrTransfer_En, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_En, 'c', Req_HdrTransfer_Enc, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_Enc, 'o', Req_HdrTransfer_Enco, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_Enco, 'd', Req_HdrTransfer_Encod, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_Encod, 'i', Req_HdrTransfer_Encodi, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_Encodi, 'n', Req_HdrTransfer_Encodin, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrTransfer_Encodin, 'g', Req_HdrTransfer_Encoding, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrTransfer_Encoding, ':', Req_HdrTransfer_EncodingV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrT, 'r', Req_HdrTr, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTr, 'a', Req_HdrTra, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTra, 'n', Req_HdrTran, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTran, 's', Req_HdrTrans, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTrans, 'f', Req_HdrTransf, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransf, 'e', Req_HdrTransfe, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfe, 'r', Req_HdrTransfer, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer, '-', Req_HdrTransfer_, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_, 'e', Req_HdrTransfer_E, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_E, 'n', Req_HdrTransfer_En, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_En, 'c', Req_HdrTransfer_Enc, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_Enc, 'o', Req_HdrTransfer_Enco, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_Enco, 'd', Req_HdrTransfer_Encod, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_Encod, 'i', Req_HdrTransfer_Encodi, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_Encodi, 'n', Req_HdrTransfer_Encodin, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrTransfer_Encodin, 'g', Req_HdrTransfer_Encoding, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrTransfer_Encoding, ':', Req_HdrTransfer_EncodingV, RGen_HdrOther);
 
 	/* X-Forwarded-For header processing. */
-	__FSM_TX_AF(Req_HdrX, '-', Req_HdrX_, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_, 'f', Req_HdrX_F, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_F, 'o', Req_HdrX_Fo, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Fo, 'r', Req_HdrX_For, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_For, 'w', Req_HdrX_Forw, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forw, 'a', Req_HdrX_Forwa, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwa, 'r', Req_HdrX_Forwar, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwar, 'd', Req_HdrX_Forward, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forward, 'e', Req_HdrX_Forwarde, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwarde, 'd', Req_HdrX_Forwarded, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwarded, '-', Req_HdrX_Forwarded_, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwarded_, 'f', Req_HdrX_Forwarded_F, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwarded_F, 'o', Req_HdrX_Forwarded_Fo, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrX_Forwarded_Fo, 'r', Req_HdrX_Forwarded_For, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrX, '-', Req_HdrX_, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_, 'f', Req_HdrX_F, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_F, 'o', Req_HdrX_Fo, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Fo, 'r', Req_HdrX_For, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_For, 'w', Req_HdrX_Forw, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forw, 'a', Req_HdrX_Forwa, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwa, 'r', Req_HdrX_Forwar, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwar, 'd', Req_HdrX_Forward, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forward, 'e', Req_HdrX_Forwarde, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwarde, 'd', Req_HdrX_Forwarded, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwarded, '-', Req_HdrX_Forwarded_, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwarded_, 'f', Req_HdrX_Forwarded_F, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwarded_F, 'o', Req_HdrX_Forwarded_Fo, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrX_Forwarded_Fo, 'r', Req_HdrX_Forwarded_For, RGen_HdrOther);
 	/* NOTE: we don't eat LWS here because RGEN_LWS() doesn't allow '[' after LWS. */
-	__FSM_TX_AF_LWS(Req_HdrX_Forwarded_For, ':', Req_HdrX_Forwarded_ForV, Req_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrX_Forwarded_For, ':', Req_HdrX_Forwarded_ForV, RGen_HdrOther);
 
 	/* User-Agent header processing. */
-	__FSM_TX_AF(Req_HdrU, 's', Req_HdrUs, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUs, 'e', Req_HdrUse, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUse, 'r', Req_HdrUser, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUser, '-', Req_HdrUser_, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUser_, 'a', Req_HdrUser_A, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUser_A, 'g', Req_HdrUser_Ag, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUser_Ag, 'e', Req_HdrUser_Age, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUser_Age, 'n', Req_HdrUser_Agen, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrUser_Agen, 't', Req_HdrUser_Agent, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrUser_Agent, ':', Req_HdrUser_AgentV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrU, 's', Req_HdrUs, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUs, 'e', Req_HdrUse, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUse, 'r', Req_HdrUser, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUser, '-', Req_HdrUser_, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUser_, 'a', Req_HdrUser_A, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUser_A, 'g', Req_HdrUser_Ag, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUser_Ag, 'e', Req_HdrUser_Age, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUser_Age, 'n', Req_HdrUser_Agen, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrUser_Agen, 't', Req_HdrUser_Agent, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrUser_Agent, ':', Req_HdrUser_AgentV, RGen_HdrOther);
 
 	/* Cookie header processing. */
-	__FSM_TX_AF(Req_HdrCoo, 'k', Req_HdrCook, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCook, 'i', Req_HdrCooki, Req_HdrOther);
-	__FSM_TX_AF(Req_HdrCooki, 'e', Req_HdrCookie, Req_HdrOther);
-	__FSM_TX_AF_LWS(Req_HdrCookie, ':', Req_HdrCookieV, Req_HdrOther);
+	__FSM_TX_AF(Req_HdrCoo, 'k', Req_HdrCook, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCook, 'i', Req_HdrCooki, RGen_HdrOther);
+	__FSM_TX_AF(Req_HdrCooki, 'e', Req_HdrCookie, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Req_HdrCookie, ':', Req_HdrCookieV, RGen_HdrOther);
 
 	}
 	__FSM_FINISH(req);
@@ -2792,7 +2805,6 @@ enum {
 	Resp_HdrTransfer_Encodin,
 	Resp_HdrTransfer_Encoding,
 	Resp_HdrTransfer_EncodingV,
-	Resp_HdrOther,
 	Resp_HdrDone,
 };
 
@@ -2943,7 +2955,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			}
 			__FSM_MOVE(Resp_HdrT);
 		default:
-			__FSM_JMP(Resp_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -2979,7 +2991,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 				__FSM_MOVE_n(Resp_HdrConnection, 9);
 			__FSM_MOVE(Resp_HdrCo);
 		default:
-			__FSM_JMP(Resp_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -3005,7 +3017,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 			}
 			__FSM_MOVE(Resp_HdrContent_T);
 		default:
-			__FSM_JMP(Resp_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
 
@@ -3043,7 +3055,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 	TFW_HTTP_PARSE_RAWHDR_VAL(Resp_HdrTransfer_EncodingV, I_TransEncod,
 				  msg, __parse_transfer_encoding);
 
-	TFW_HTTP_PARSE_HDR_OTHER(Resp);
+	RGEN_HDR_OTHER();
 
 	/* ----------------    Response body    ---------------- */
 
@@ -3073,21 +3085,21 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 	__FSM_TX(Resp_SSpace, ' ', Resp_StatusCode);
 
 	/* Cache-Control header processing. */
-	__FSM_TX_AF(Resp_HdrCa, 'c', Resp_HdrCac, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCac, 'h', Resp_HdrCach, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCach, 'e', Resp_HdrCache, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache, '-', Resp_HdrCache_, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_, 'c', Resp_HdrCache_C, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_C, 'o', Resp_HdrCache_Co, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_Co, 'n', Resp_HdrCache_Con, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_Con, 't', Resp_HdrCache_Cont, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_Cont, 'r', Resp_HdrCache_Contr, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_Contr, 'o', Resp_HdrCache_Contro, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrCache_Contro, 'l', Resp_HdrCache_Control, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrCache_Control, ':', Resp_HdrCache_ControlV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrCa, 'c', Resp_HdrCac, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCac, 'h', Resp_HdrCach, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCach, 'e', Resp_HdrCache, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache, '-', Resp_HdrCache_, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_, 'c', Resp_HdrCache_C, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_C, 'o', Resp_HdrCache_Co, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_Co, 'n', Resp_HdrCache_Con, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_Con, 't', Resp_HdrCache_Cont, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_Cont, 'r', Resp_HdrCache_Contr, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_Contr, 'o', Resp_HdrCache_Contro, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrCache_Contro, 'l', Resp_HdrCache_Control, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrCache_Control, ':', Resp_HdrCache_ControlV, RGen_HdrOther);
 
 	/* Connection header processing. */
-	__FSM_TX_AF(Resp_HdrCo, 'n', Resp_HdrCon, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrCo, 'n', Resp_HdrCon, RGen_HdrOther);
 	__FSM_STATE(Resp_HdrCon) {
 		switch (LC(c)) {
 		case 'n':
@@ -3095,84 +3107,84 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 		case 't':
 			__FSM_MOVE(Resp_HdrCont);
 		default:
-			__FSM_JMP(Resp_HdrOther);
+			__FSM_JMP(RGen_HdrOther);
 		}
 	}
-	__FSM_TX_AF(Resp_HdrConn, 'e', Resp_HdrConne, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConne, 'c', Resp_HdrConnec, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConnec, 't', Resp_HdrConnect, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConnect, 'i', Resp_HdrConnecti, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConnecti, 'o', Resp_HdrConnectio, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConnectio, 'n', Resp_HdrConnection, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrConnection, ':', Resp_HdrConnectionV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrConn, 'e', Resp_HdrConne, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConne, 'c', Resp_HdrConnec, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConnec, 't', Resp_HdrConnect, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConnect, 'i', Resp_HdrConnecti, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConnecti, 'o', Resp_HdrConnectio, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConnectio, 'n', Resp_HdrConnection, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrConnection, ':', Resp_HdrConnectionV, RGen_HdrOther);
 
 	/* Content-* headers processing. */
-	__FSM_TX_AF(Resp_HdrCont, 'e', Resp_HdrConte, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConte, 'n', Resp_HdrConten, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrConten, 't', Resp_HdrContent, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent, '-', Resp_HdrContent_, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrCont, 'e', Resp_HdrConte, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConte, 'n', Resp_HdrConten, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrConten, 't', Resp_HdrContent, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent, '-', Resp_HdrContent_, RGen_HdrOther);
 
 	/* Content-Length header processing. */
-	__FSM_TX_AF(Resp_HdrContent_L, 'e', Resp_HdrContent_Le, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent_Le, 'n', Resp_HdrContent_Len, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent_Len, 'g', Resp_HdrContent_Leng, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent_Leng, 't', Resp_HdrContent_Lengt, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent_Lengt, 'h', Resp_HdrContent_Length, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrContent_Length, ':', Resp_HdrContent_LengthV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_L, 'e', Resp_HdrContent_Le, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_Le, 'n', Resp_HdrContent_Len, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_Len, 'g', Resp_HdrContent_Leng, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_Leng, 't', Resp_HdrContent_Lengt, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_Lengt, 'h', Resp_HdrContent_Length, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrContent_Length, ':', Resp_HdrContent_LengthV, RGen_HdrOther);
 
 	/* Content-Type header processing. */
-	__FSM_TX_AF(Resp_HdrContent_T, 'y', Resp_HdrContent_Ty, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent_Ty, 'p', Resp_HdrContent_Typ, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrContent_Typ, 'e', Resp_HdrContent_Type, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrContent_Type, ':', Resp_HdrContent_TypeV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_T, 'y', Resp_HdrContent_Ty, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_Ty, 'p', Resp_HdrContent_Typ, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrContent_Typ, 'e', Resp_HdrContent_Type, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrContent_Type, ':', Resp_HdrContent_TypeV, RGen_HdrOther);
 
 	/* Expires header processing. */
-	__FSM_TX_AF(Resp_HdrE, 'x', Resp_HdrEx, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrEx, 'p', Resp_HdrExp, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrExp, 'i', Resp_HdrExpi, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrExpi, 'r', Resp_HdrExpir, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrExpir, 'e', Resp_HdrExpire, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrExpire, 's', Resp_HdrExpires, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrExpires, ':', Resp_HdrExpiresV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrE, 'x', Resp_HdrEx, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrEx, 'p', Resp_HdrExp, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrExp, 'i', Resp_HdrExpi, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrExpi, 'r', Resp_HdrExpir, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrExpir, 'e', Resp_HdrExpire, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrExpire, 's', Resp_HdrExpires, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrExpires, ':', Resp_HdrExpiresV, RGen_HdrOther);
 
 	/* Keep-Alive header processing. */
-	__FSM_TX_AF(Resp_HdrK, 'e', Resp_HdrKe, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKe, 'e', Resp_HdrKee, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKee, 'p', Resp_HdrKeep, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKeep, '-', Resp_HdrKeep_, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKeep_, 'a', Resp_HdrKeep_A, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKeep_A, 'l', Resp_HdrKeep_Al, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKeep_Al, 'i', Resp_HdrKeep_Ali, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKeep_Ali, 'v', Resp_HdrKeep_Aliv, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrKeep_Aliv, 'e', Resp_HdrKeep_Alive, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrKeep_Alive, ':', Resp_HdrKeep_AliveV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrK, 'e', Resp_HdrKe, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKe, 'e', Resp_HdrKee, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKee, 'p', Resp_HdrKeep, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKeep, '-', Resp_HdrKeep_, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKeep_, 'a', Resp_HdrKeep_A, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKeep_A, 'l', Resp_HdrKeep_Al, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKeep_Al, 'i', Resp_HdrKeep_Ali, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKeep_Ali, 'v', Resp_HdrKeep_Aliv, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrKeep_Aliv, 'e', Resp_HdrKeep_Alive, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrKeep_Alive, ':', Resp_HdrKeep_AliveV, RGen_HdrOther);
 
 	/* Server header processing. */
-	__FSM_TX_AF(Resp_HdrS, 'e', Resp_HdrSe, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrSe, 'r', Resp_HdrSer, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrSer, 'v', Resp_HdrServ, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrServ, 'e', Resp_HdrServe, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrServe, 'r', Resp_HdrServer, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrServer, ':', Resp_HdrServerV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrS, 'e', Resp_HdrSe, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrSe, 'r', Resp_HdrSer, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrSer, 'v', Resp_HdrServ, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrServ, 'e', Resp_HdrServe, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrServe, 'r', Resp_HdrServer, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrServer, ':', Resp_HdrServerV, RGen_HdrOther);
 
 	/* Transfer-Encoding header processing. */
-	__FSM_TX_AF(Resp_HdrT, 'r', Resp_HdrTr, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTr, 'a', Resp_HdrTra, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTra, 'n', Resp_HdrTran, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTran, 's', Resp_HdrTrans, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTrans, 'f', Resp_HdrTransf, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransf, 'e', Resp_HdrTransfe, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfe, 'r', Resp_HdrTransfer, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer, '-', Resp_HdrTransfer_, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_, 'e', Resp_HdrTransfer_E, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_E, 'n', Resp_HdrTransfer_En, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_En, 'c', Resp_HdrTransfer_Enc, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_Enc, 'o', Resp_HdrTransfer_Enco, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_Enco, 'd', Resp_HdrTransfer_Encod, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_Encod, 'i', Resp_HdrTransfer_Encodi, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_Encodi, 'n', Resp_HdrTransfer_Encodin, Resp_HdrOther);
-	__FSM_TX_AF(Resp_HdrTransfer_Encodin, 'g', Resp_HdrTransfer_Encoding, Resp_HdrOther);
-	__FSM_TX_AF_LWS(Resp_HdrTransfer_Encoding, ':', Resp_HdrTransfer_EncodingV, Resp_HdrOther);
+	__FSM_TX_AF(Resp_HdrT, 'r', Resp_HdrTr, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTr, 'a', Resp_HdrTra, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTra, 'n', Resp_HdrTran, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTran, 's', Resp_HdrTrans, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTrans, 'f', Resp_HdrTransf, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransf, 'e', Resp_HdrTransfe, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfe, 'r', Resp_HdrTransfer, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer, '-', Resp_HdrTransfer_, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_, 'e', Resp_HdrTransfer_E, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_E, 'n', Resp_HdrTransfer_En, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_En, 'c', Resp_HdrTransfer_Enc, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_Enc, 'o', Resp_HdrTransfer_Enco, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_Enco, 'd', Resp_HdrTransfer_Encod, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_Encod, 'i', Resp_HdrTransfer_Encodi, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_Encodi, 'n', Resp_HdrTransfer_Encodin, RGen_HdrOther);
+	__FSM_TX_AF(Resp_HdrTransfer_Encodin, 'g', Resp_HdrTransfer_Encoding, RGen_HdrOther);
+	__FSM_TX_AF_LWS(Resp_HdrTransfer_Encoding, ':', Resp_HdrTransfer_EncodingV, RGen_HdrOther);
 
 	}
 	__FSM_FINISH(resp);

--- a/tempesta_fw/http_parser.c
+++ b/tempesta_fw/http_parser.c
@@ -43,8 +43,12 @@
 /* Common states. */
 enum {
 	RGen_LWS = 10000,
-	RGen_LF,
 	RGen_LWS_empty,
+	RGen_EoL, RGen__EoL,
+	RGen_Hdr,
+	RGen_Body,
+	RGen_BodyChunkExt,
+	RGen_BodyReadChunk,
 };
 
 /**
@@ -57,6 +61,43 @@ __field_finish(TfwHttpMsg *hm, TfwStr *field,
 	tfw_http_msg_field_chunk_fixup(hm, field, begin, end - begin);
 	field->flags |= TFW_STR_COMPLETE;
 }
+
+/**
+ * Check whether a character is CR or LF.
+ */
+#define IS_CR_OR_LF(c) (c == '\r' || c == '\n')
+
+/**
+ * Scans the initial @n bytes of the memory area pointed to by @s for the first
+ * occurance of EOL character.
+ *
+ * NOTE: We can use @strcspn here, but at the moment it's generic implementation
+ * from the kernel's library is more badly than the @memchreol provided as: 1)
+ * it uses for-in-for logic that can't be optimized at compile time 2) it
+ * operates on zero-terminated strings so needless string boudary check occures
+ * on every iteration 3) it returns not the pointer but the number of bytes, so
+ * additinal logic needs to be implemented while preparing the result.
+ *
+ * In any case, it will be a good deal to rewrite such a function using
+ * vectorized extenstions such as AVX/SSE in the future.
+ *
+ * Related to #182 (https://github.com/natsys/tempesta/issues/182)
+ */
+static inline unsigned char *
+memchreol(const unsigned char *s, size_t n)
+{
+	while (n) {
+		if (IS_CR_OR_LF(*s))
+			return (unsigned char *)s;
+		s++, n--;
+	}
+	return NULL;
+}
+
+/**
+ * Check whether a character is a whitespace (RWS/OWS/BWS according to RFC7230).
+ */
+#define IS_WS(c) (c == ' ' || c == '\t')
 
 /**
  * GCC 4.8 (CentOS 7) does a poor work on memory reusage of automatic local
@@ -401,6 +442,144 @@ enum {
 #define TRY_STR(str, state)						\
 	TRY_STR_LAMBDA(str, { }, state)
 
+/**
+ * Close currently processed header and set it's EOL length value properly
+ * according to parser's EOL state.
+ */
+static inline int
+__header_close_at_eol(TfwHttpMsg *msg)
+{
+	TfwHttpParser *parser = &msg->parser;
+	/* Skip headers that were not opened */
+	if (msg->parser.hdr.ptr) {
+		/* LF and CRLF are the only valid EOL values */
+		int eolen = 1 + !!(parser->_tmp.eol == 0xda);
+		tfw_str_set_eolen(&parser->hdr, eolen);
+		return tfw_http_msg_hdr_close(msg, parser->_hdr_tag);
+	}
+	return TFW_PASS;
+}
+
+#define RGEN_EOL()							\
+__FSM_STATE(RGen_EoL) {							\
+	parser->_tmp.eol = 0;						\
+	/* Fall through */						\
+}									\
+__FSM_STATE(RGen__EoL) {						\
+	if (likely(IS_CR_OR_LF(c))) {					\
+		/*							\
+		 * We use special register to track line endings. New	\
+		 * characters are appended to the beginning while old	\
+		 * characters are shifted left. The lower 4 bits used	\
+		 * to track CR/LF characters.				\
+		 */							\
+		parser->_tmp.eol = (parser->_tmp.eol << 4) | (c & 0xf);	\
+		TFW_DBG3("parser: eol %08lx\n", parser->_tmp.eol);	\
+									\
+		/*							\
+		 * We have a number of valid CR/LF mixtures. Any other	\
+		 * mixtures must be blocked:				\
+		 *							\
+		 *  LF          - next header / empty-line (incomplete)	\
+		 *  CR LF       - next header / empty-line (incomplete)	\
+		 *  CR          - (incomplete)				\
+		 *  LF CR       - empty-line (incomplete)		\
+		 *  LF LF       - empty-line				\
+		 *  LF CR LF    - empty-line				\
+		 *  CR LF CR    - empty-line (incomplete)		\
+		 *  CR LF LF    - empty-line				\
+		 *  CR LF CR LF - empty-line				\
+		 */							\
+		switch (parser->_tmp.eol) {				\
+		case 0xa:						\
+		case 0xda:						\
+			if (__header_close_at_eol(msg))			\
+				return TFW_BLOCK;			\
+			/* Fall through */				\
+		case 0xd:						\
+		case 0xad:						\
+		case 0xaa:						\
+		case 0xada:						\
+		case 0xdad:						\
+		case 0xdaa:						\
+		case 0xdada:						\
+			goto good_looking_eol;				\
+		}							\
+									\
+		return TFW_BLOCK;					\
+									\
+good_looking_eol:							\
+									\
+		/*							\
+		 * Set empty-line mark only if LFxx or CRLFxx was	\
+		 * catched and crlf wasn't completed yet by		\
+		 * @__field_finish function.				\
+		 */							\
+		if ((parser->_tmp.eol & 0xf0) == 0xa0) {		\
+			if (!(msg->crlf.flags & TFW_STR_COMPLETE))	\
+				tfw_http_msg_set_data(msg, &msg->crlf, p); \
+		}							\
+									\
+		/*							\
+		 * Check for the empty-line (EOL + EOL) mixture here as	\
+		 * it can be handled immediately.			\
+		 */							\
+		switch (parser->_tmp.eol) {				\
+		case 0xaa:						\
+		case 0xada:						\
+		case 0xdaa:						\
+		case 0xdada:						\
+			parser->_tmp.eol = 0;				\
+			if (!(msg->crlf.flags & TFW_STR_COMPLETE)) {	\
+				__field_finish(msg, &msg->crlf, data, p + 1); \
+				TFW_HTTP_INIT_BODY_PARSING(msg, RGen_Body); \
+			} else if (msg->body.flags & TFW_STR_COMPLETE) { \
+				r = TFW_PASS;				\
+				FSM_EXIT();				\
+			} else {					\
+				return TFW_BLOCK;			\
+			}						\
+		}							\
+									\
+		/*							\
+		 * Can't make desicion right now as the EOL-sequence	\
+		 * is incomplete. So, let's try to do it on the next	\
+		 * pass.						\
+		 */							\
+									\
+		__FSM_MOVE(RGen__EoL);					\
+	}								\
+									\
+	TFW_DBG3("parser: eol %08lx +%02x(%c)\n",			\
+		 parser->_tmp.eol, c, isprint(c) ? c : '.');		\
+									\
+	/*								\
+	 * Non EOL character was received after some CR/LF		\
+	 * characters. This usually happens after the end of line, but	\
+	 * the tracked sequence may be incomplete. So, we need to	\
+	 * check for allowed line endings (LF or CRLF).			\
+	 */								\
+	if (!(parser->_tmp.eol == 0xa || parser->_tmp.eol == 0xda))	\
+		return TFW_BLOCK;					\
+									\
+	parser->_tmp.eol = 0;						\
+									\
+	/*								\
+	 * According to RFC 7230, HTTP-headers may appear in two	\
+	 * cases. The first one is parsing header section (3.2) and	\
+	 * the second one is parsing chunked-body trailer-part (4.1).	\
+	 */								\
+	if (!(msg->crlf.flags & TFW_STR_COMPLETE) ||			\
+	     (msg->body.flags & TFW_STR_COMPLETE))			\
+		__FSM_JMP(RGen_Hdr);					\
+									\
+	/*								\
+	 * The next chunk of chunked-body payload (RFC 7320, 4.1.2)	\
+	 * needs to be handled.						\
+	 */								\
+	__FSM_JMP(RGen_Body);						\
+}
+
 /*
  * We have HTTP message descriptors and special headers,
  * however we still need to store full headers (instead of just their values)
@@ -440,10 +619,9 @@ __FSM_STATE(st_curr) {							\
 		/* The header value is fully parsed, move forward. */	\
 		if (saveval)						\
 			tfw_http_msg_hdr_chunk_fixup(msg, p, __fsm_n);	\
-		if (tfw_http_msg_hdr_close(msg, id))			\
-			return TFW_BLOCK;				\
-		parser->_i_st = I_0;					\
-		__FSM_MOVE_n(RGen_LF, __fsm_n + 1); /* skip \r */	\
+		parser->_i_st = RGen_EoL;				\
+		parser->_hdr_tag = id;					\
+		__FSM_MOVE_n(RGen_LWS_empty, __fsm_n); /* skip OWS */	\
 	}								\
 }
 
@@ -478,10 +656,9 @@ __FSM_STATE(st_curr) {							\
 		BUG_ON(__fsm_n < 0);					\
 		/* The header value is fully parsed, move forward. */	\
 		tfw_http_msg_hdr_chunk_fixup(msg, p, __fsm_n);		\
-		if (tfw_http_msg_hdr_close(msg, TFW_HTTP_HDR_RAW))	\
-			return TFW_BLOCK;				\
-		parser->_i_st = I_0;					\
-		__FSM_MOVE_n(RGen_LF, __fsm_n + 1); /* skip \r */	\
+		parser->_i_st = RGen_EoL;				\
+		parser->_hdr_tag = TFW_HTTP_HDR_RAW;			\
+		__FSM_MOVE_n(RGen_LWS_empty, __fsm_n); /* skip OWS */	\
 	}								\
 }
 
@@ -496,24 +673,16 @@ __FSM_STATE(st_curr) {							\
  */
 #define TFW_HTTP_PARSE_HDR_OTHER(prefix)				\
 __FSM_STATE(prefix ## _HdrOther) {					\
-	/* Just eat the header until LF. */				\
+	/* Just eat the header until EOL. */				\
 	__fsm_sz = len - (size_t)(p - data);				\
-	__fsm_ch = memchr(p, '\r', __fsm_sz);				\
+	__fsm_ch = memchreol(p, __fsm_sz);				\
 	if (__fsm_ch) {							\
 		/* Get length of the header. */				\
 		tfw_http_msg_hdr_chunk_fixup(msg, data, __fsm_ch - data);\
-		if (tfw_http_msg_hdr_close(msg, TFW_HTTP_HDR_RAW))	\
-			return TFW_BLOCK;				\
-		__FSM_MOVE_n(RGen_LF, __fsm_ch - p + 1);		\
+		parser->_hdr_tag = TFW_HTTP_HDR_RAW;			\
+		__FSM_MOVE_n(RGen_EoL, __fsm_ch - p);			\
 	}								\
 	__FSM_MOVE_n(prefix ## _HdrOther, __fsm_sz);			\
-}
-
-#define TFW_HTTP_PARSE_LF(prefix)					\
-__FSM_STATE(RGen_LF) {							\
-	if (likely(c == '\n'))						\
-		__FSM_MOVE(prefix ## _Hdr);				\
-	return TFW_BLOCK;						\
 }
 
 /*
@@ -561,9 +730,9 @@ do {									\
 	FSM_EXIT();							\
 } while (0)
 
-#define TFW_HTTP_PARSE_BODY(prefix)					\
+#define TFW_HTTP_PARSE_BODY()						\
 /* Read request|response body. */					\
-__FSM_STATE(prefix ## _Body) {						\
+__FSM_STATE(RGen_Body) {						\
 	TFW_DBG3("read body: to_read=%d\n", parser->to_read);		\
 	if (!parser->to_read) {						\
 		__fsm_sz = len - (size_t)(p - data);			\
@@ -574,7 +743,7 @@ __FSM_STATE(prefix ## _Body) {						\
 		switch (__fsm_n) {					\
 		case CSTR_POSTPONE:					\
 			/* Not all data has been parsed. */		\
-			__FSM_B_MOVE_n(prefix ## _Body, __fsm_sz);	\
+			__FSM_B_MOVE_n(RGen_Body, __fsm_sz);		\
 		case CSTR_BADLEN: /* bad header length */		\
 		case CSTR_NEQ: /* bad header value */			\
 			return TFW_BLOCK;				\
@@ -583,69 +752,48 @@ __FSM_STATE(prefix ## _Body) {						\
 			if (unlikely(__fsm_n == 0))			\
 				return TFW_BLOCK;			\
 			parser->to_read = parser->_tmp.acc;		\
+			if (!parser->to_read)				\
+				msg->body.flags |= TFW_STR_COMPLETE;	\
 			parser->_tmp.acc = 0;				\
-			__FSM_B_MOVE_n(prefix ## _BodyChunkEoL, __fsm_n); \
+			__FSM_B_MOVE_n(RGen_BodyChunkExt, __fsm_n);	\
 		}							\
 	}								\
 	/* fall through */						\
 }									\
 /* Read parser->to_read bytes of message body. */			\
-__FSM_STATE(prefix ## _BodyReadChunk) {					\
+__FSM_STATE(RGen_BodyReadChunk) {					\
 	__fsm_sz = min(parser->to_read, (int)(len - (size_t)(p - data))); \
 	if (tfw_http_msg_add_data_ptr(msg, &msg->body, p, __fsm_sz))	\
 		return TFW_BLOCK;					\
 	parser->to_read -= __fsm_sz;					\
 	/* Just skip required number of bytes. */			\
 	if (parser->to_read)						\
-		__FSM_B_MOVE_n(prefix ## _BodyReadChunk, __fsm_sz);	\
+		__FSM_B_MOVE_n(RGen_BodyReadChunk, __fsm_sz);		\
 	if (msg->flags & TFW_HTTP_CHUNKED)				\
-		__FSM_B_MOVE_n(prefix ## _BodyChunkEnd, __fsm_sz);	\
+		__FSM_B_MOVE_n(RGen_EoL, __fsm_sz);			\
 	/* We've fully read Content-Length bytes. */			\
 	p += __fsm_sz;							\
 	r = TFW_PASS;							\
 	goto done;							\
 }									\
-__FSM_STATE(prefix ## _BodyChunkEoL) {					\
-	if (c == '\n') {						\
-		if (parser->to_read) {					\
-			__FSM_B_MOVE(prefix ## _BodyReadChunk);		\
-		}							\
-		else {							\
-			msg->body.flags |= TFW_STR_COMPLETE;		\
-			/* Read trailing headers, RFC 7230 4.1.2. */	\
-			__FSM_B_MOVE(prefix ## _Hdr);			\
-		}							\
-	}								\
-	if (c == '\r' || c == '=' || IN_ALPHABET(*p, hdr_a) || c == ';') \
-		__FSM_B_MOVE(prefix ## _BodyChunkEoL);			\
-	return TFW_BLOCK;						\
-}									\
-__FSM_STATE(prefix ## _BodyChunkEnd) {					\
-	if (c == '\n') {						\
-		__FSM_B_MOVE(prefix ## _Body);				\
-	}								\
-	if (c == '\r')							\
-		__FSM_B_MOVE(prefix ## _BodyChunkEnd);			\
-	return TFW_BLOCK;						\
-}									\
-/* Request|Response is fully read. */					\
-__FSM_STATE(prefix ## _Done) {						\
-	if (c == '\n') {						\
-		r = TFW_PASS;						\
-		FSM_EXIT();						\
+__FSM_STATE(RGen_BodyChunkExt) {					\
+	if (likely(IS_CR_OR_LF(c))) {					\
+		__FSM_JMP(RGen_EoL);					\
+	} else if (c == ';' || c == '=' || IN_ALPHABET(c, hdr_a)) {	\
+		__FSM_B_MOVE(RGen_BodyChunkExt);			\
 	}								\
 	return TFW_BLOCK;						\
 }
 
 #define RGEN_LWS_common_cases(st)					\
-	case ' ':							\
-	case '\t':							\
+	else if (likely(IS_WS(c))) {					\
 		__FSM_MOVE(st);						\
-	default:							\
+	} else {							\
 		parser->state = parser->_i_st;				\
 		parser->_i_st = 0;					\
 		BUG_ON(unlikely(p >= data + len || !*p));		\
-		goto fsm_reenter;
+		goto fsm_reenter;					\
+	}
 
 /* In request we should pass empty headers:
  * RFC 7230 5.4:
@@ -664,27 +812,18 @@ __FSM_STATE(prefix ## _Done) {						\
  */
 #define RGEN_LWS_empty()						\
 __FSM_STATE(RGen_LWS_empty) {						\
-	switch (c) {							\
-	case '\r':							\
-	case '\n':							\
-		tfw_http_msg_hdr_chunk_fixup(msg, data, p - data);	\
-		if (tfw_http_msg_hdr_close(msg, parser->_hdr_tag))	\
-			return TFW_BLOCK;				\
-		if (c == '\r')						\
-			__FSM_MOVE(RGen_LF);				\
-		__FSM_JMP(RGen_LF);					\
-	RGEN_LWS_common_cases(RGen_LWS_empty)				\
+	if (unlikely(IS_CR_OR_LF(c))) {					\
+		__FSM_JMP(RGen_EoL);					\
 	}								\
+	RGEN_LWS_common_cases(RGen_LWS_empty)				\
 }
 
 #define RGEN_LWS()							\
 __FSM_STATE(RGen_LWS) {							\
-	switch (c) {							\
-	case '\n':							\
-	case '\r':							\
+	if (unlikely(IS_CR_OR_LF(c))) {					\
 		return TFW_BLOCK;					\
-	RGEN_LWS_common_cases(RGen_LWS)					\
 	}								\
+	RGEN_LWS_common_cases(RGen_LWS)					\
 }
 
 /**
@@ -730,7 +869,7 @@ __parse_connection(TfwHttpMsg *msg, unsigned char *data, size_t len)
 		 */
 		unsigned char *comma;
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		comma = memchr(p, ',', __fsm_sz);
 		if (comma && (!__fsm_ch || (__fsm_ch && (comma < __fsm_ch))))
 			__FSM_I_MOVE_n(I_EoT, comma - p);
@@ -745,7 +884,7 @@ __parse_connection(TfwHttpMsg *msg, unsigned char *data, size_t len)
 			__FSM_I_MOVE(I_EoT);
 		if (IN_ALPHABET(c, hdr_a))
 			__FSM_I_MOVE_n(I_Conn, 0);
-		if (c == '\r')
+		if (IS_CR_OR_LF(c))
 			return p - data;
 		return CSTR_NEQ;
 	}
@@ -797,7 +936,7 @@ __parse_content_type(TfwHttpMsg *msg, unsigned char *data, size_t len)
 		 *   null-terminated strings.
 		 */
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		if (__fsm_ch)
 			return __fsm_ch - data;
 		__FSM_I_MOVE_n(I_ContType, __fsm_sz);
@@ -841,7 +980,7 @@ __parse_transfer_encoding(TfwHttpMsg *msg, unsigned char *data, size_t len)
 		 */
 		unsigned char *comma;
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		comma = memchr(p, ',', __fsm_sz);
 		if (comma && (!__fsm_ch || (__fsm_ch && (comma < __fsm_ch))))
 			__FSM_I_MOVE_n(I_EoT, comma - p);
@@ -856,7 +995,7 @@ __parse_transfer_encoding(TfwHttpMsg *msg, unsigned char *data, size_t len)
 			__FSM_I_MOVE(I_EoT);
 		if (IN_ALPHABET(c, hdr_a))
 			__FSM_I_MOVE(I_TransEncod);
-		if (c == '\r')
+		if (IS_CR_OR_LF(c))
 			return p - data;
 		return CSTR_NEQ;
 	}
@@ -906,11 +1045,6 @@ static const unsigned long xff_a[] ____cacheline_aligned = {
 	0x7ff600000000000UL, 0x7fffffeaffffffeUL, 0, 0
 };
 
-/**
- * Check whether a character is a whitespace (RWS/OWS/BWS according to RFC7230).
- */
-#define IS_WS(c) (c == ' ' || c == '\t')
-
 /* Main (parent) HTTP request processing states. */
 enum {
 	Req_0,
@@ -952,7 +1086,6 @@ enum {
 	Req_HttpVer11,
 	Req_HttpVerDot,
 	Req_HttpVer12,
-	Req_EoL,
 	/* Headers. */
 	Req_Hdr,
 	Req_HdrH,
@@ -1052,16 +1185,9 @@ enum {
 	Req_HdrUser_Agent,
 	Req_HdrUser_AgentV,
 	Req_HdrOther,
-	Req_HdrDone,
 	/* Body */
-	Req_Body,
-	Req_BodyChunkEoL,
-	Req_BodyChunkEnd,
-	Req_BodyReadChunk,
 	/* URI normalization. */
 	Req_UriNorm,
-	/* Request parsing done. */
-	Req_Done
 };
 #ifdef TFW_HTTP_NORMALIZATION
 #define TFW_HTTP_URI_HOOK	Req_UriNorm
@@ -1182,7 +1308,7 @@ __req_parse_cache_control(TfwHttpReq *req, unsigned char *data, size_t len)
 		 */
 		unsigned char *comma;
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		comma = memchr(p, ',', __fsm_sz);
 		if (comma && (!__fsm_ch || (__fsm_ch && (comma < __fsm_ch))))
 			__FSM_I_MOVE_n(Req_I_CC_EoT, comma - p);
@@ -1204,7 +1330,7 @@ __req_parse_cache_control(TfwHttpReq *req, unsigned char *data, size_t len)
 			__FSM_I_MOVE(Req_I_CC_Ext);
 		if (IN_ALPHABET(c, hdr_a))
 			__FSM_I_MOVE_n(Req_I_CC, 0);
-		if (c == '\r')
+		if (IS_CR_OR_LF(c))
 			return p - data;
 		return CSTR_NEQ;
 	}
@@ -1323,12 +1449,12 @@ __req_parse_x_forwarded_for(TfwHttpMsg *msg, unsigned char *data, size_t len)
 	__FSM_STATE(Req_I_XFF_Sep) {
 		/*
 		 * Proxy chains are rare, so we expect that the list will end
-		 * after the first node and we get '\r' here.
+		 * after the first node and we get EOL here.
 		 */
-		if (likely(c == '\r'))
+		if (likely(IS_CR_OR_LF(c)))
 			return p - data;
 
-		/* OWS before comma or before \r\n (is unusual). */
+		/* OWS before comma or before EOL (is unusual). */
 		if (unlikely(IS_WS(c)))
 			__FSM_I_MOVE(Req_I_XFF_Sep);
 
@@ -1360,7 +1486,7 @@ __req_parse_user_agent(TfwHttpMsg *msg, unsigned char *data, size_t len)
 
 	__FSM_STATE(Req_I_UserAgent) {
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		if (__fsm_ch)
 			return __fsm_ch - data;
 		__FSM_I_MOVE_n(Req_I_UserAgent, __fsm_sz);
@@ -1389,6 +1515,28 @@ __req_parse_cookie(TfwHttpMsg *msg, unsigned char *data, size_t len)
 	 * to split it in chunks: chunk bounds are
 	 * at least at name start, value start and value end.
 	 * This simplifies cookie search, http_sticky uses it.
+	 *
+	 * According to RFC 6265 the cookie header must
+	 * conform to the following grammar:
+	 *
+	 *   cookie-header = "Cookie:" OWS cookie-string OWS
+	 *   cookie-string = cookie-pair *( ";" SP cookie-pair )
+	 *
+	 *   cookie-pair   = cookie-name "=" cookie-value
+	 *
+	 *   cookie-name   = token
+	 *   cookie-value  = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
+	 *
+	 * RFC 2616 (2.2) defines token as:
+	 *
+	 *   token         = 1*<any CHAR except CTLs or separators>
+	 *   separators    = "(" | ")" | "<" | ">" | "@"
+	 *                 | "," | ";" | ":" | "\" | <">
+	 *                 | "/" | "[" | "]" | "?" | "="
+	 *                 | "{" | "}" | SP | HT
+	 *
+	 * TODO: validate `cookie-name` and `cookie-value`
+	 *       against allowed characters set
 	 */
 	__FSM_START(parser->_i_st) {
 
@@ -1416,7 +1564,7 @@ __req_parse_cookie(TfwHttpMsg *msg, unsigned char *data, size_t len)
 		if (unlikely(c == ';'))
 			/* do not save ';' yet */
 			__FSM_I_MOVE_fixup(Req_I_CookieSP, 0, TFW_STR_VALUE);
-		if (unlikely(c == '\r' || c == ' ')) {
+		if (unlikely(isspace(c))) {
 			/* do not save LWS */
 			tfw_http_msg_hdr_chunk_fixup(msg, data, p - data);
 			__FSM_I_chunk_flags(TFW_STR_VALUE);
@@ -1458,7 +1606,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 	/* ----------------    Request Line    ---------------- */
 
 	__FSM_STATE(Req_0) {
-		if (unlikely(c == '\r' || c == '\n'))
+		if (unlikely(IS_CR_OR_LF(c)))
 			__FSM_MOVE(Req_0);
 		/* fall through */
 	}
@@ -1661,22 +1809,10 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 		switch (*(unsigned long *)p) {
 		case TFW_CHAR8_INT('H', 'T', 'T', 'P', '/', '1', '.', '1'):
 			req->version = TFW_HTTP_VER_11;
-			__FSM_MOVE_n(Req_EoL, 8);
+			__FSM_MOVE_n(RGen_EoL, 8);
 		case TFW_CHAR8_INT('H', 'T', 'T', 'P', '/', '1', '.', '0'):
 			req->version = TFW_HTTP_VER_10;
-			__FSM_MOVE_n(Req_EoL, 8);
-		default:
-			return TFW_BLOCK;
-		}
-	}
-
-	/* End of HTTP line (request or header). */
-	__FSM_STATE(Req_EoL) {
-		switch (c) {
-		case '\r':
-			__FSM_MOVE(Req_EoL);
-		case '\n':
-			__FSM_MOVE(Req_Hdr);
+			__FSM_MOVE_n(RGen_EoL, 8);
 		default:
 			return TFW_BLOCK;
 		}
@@ -1688,31 +1824,7 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 	 * Start of HTTP header or end of header part of the request.
 	 * There is a switch for first character of a header name.
 	 */
-	__FSM_STATE(Req_Hdr) {
-		if (unlikely(c == '\r')) {
-			if (!(req->body.flags & TFW_STR_COMPLETE)) {
-				tfw_http_msg_set_data(msg, &req->crlf, p);
-				__FSM_MOVE(Req_HdrDone);
-			} else {
-				__FSM_MOVE(Req_Done);
-			}
-		}
-		if (unlikely(c == '\n')) {
-			if (!(req->body.flags & TFW_STR_COMPLETE)) {
-				/*
-				 * RFC 7230 3.5 allows single LF
-				 * without CR as an exception.
-				 */
-				if (unlikely(!req->crlf.ptr))
-					tfw_http_msg_set_data(msg, &req->crlf,
-							      p);
-				TFW_HTTP_INIT_BODY_PARSING(req, Req_Body);
-			} else {
-				r = TFW_PASS;
-				FSM_EXIT();
-			}
-		}
-
+	__FSM_STATE(RGen_Hdr) {
 		if (unlikely(!IN_ALPHABET(c, hdr_a)))
 			return TFW_BLOCK;
 
@@ -1772,8 +1884,9 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 		}
 	}
 
-	RGEN_LWS_empty();
+	RGEN_EOL();
 	RGEN_LWS();
+	RGEN_LWS_empty();
 
 	/* Parse headers starting from 'C'. */
 	__FSM_STATE(Req_HdrC) {
@@ -1883,20 +1996,9 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 
 	TFW_HTTP_PARSE_HDR_OTHER(Req);
 
-	TFW_HTTP_PARSE_LF(Req);
-
-	/* Request headers are fully read. */
-	__FSM_STATE(Req_HdrDone) {
-		if (c == '\n') {
-			__field_finish(msg, &req->crlf, data, p + 1);
-			TFW_HTTP_INIT_BODY_PARSING(req, Req_Body);
-		}
-		return TFW_BLOCK;
-	}
-
 	/* ----------------    Request body    ---------------- */
 
-	TFW_HTTP_PARSE_BODY(Req);
+	TFW_HTTP_PARSE_BODY();
 
 	/* ----------------    Improbable states    ---------------- */
 
@@ -1950,10 +2052,10 @@ tfw_http_parse_req(void *req_data, unsigned char *data, size_t len)
 		switch(c) {
 		case '1':
 			req->version = TFW_HTTP_VER_11;
-			__FSM_MOVE(Req_EoL);
+			__FSM_MOVE(RGen_EoL);
 		case '0':
 			req->version = TFW_HTTP_VER_10;
-			__FSM_MOVE(Req_EoL);
+			__FSM_MOVE(RGen_EoL);
 		default:
 			return TFW_BLOCK;
 		}
@@ -2226,7 +2328,7 @@ __resp_parse_cache_control(TfwHttpResp *resp, unsigned char *data, size_t len)
 		 */
 		unsigned char *comma;
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		comma = memchr(p, ',', __fsm_sz);
 		if (comma && (!__fsm_ch || (__fsm_ch && (comma < __fsm_ch))))
 			__FSM_I_MOVE_n(Resp_I_EoT, comma - p);
@@ -2248,7 +2350,7 @@ __resp_parse_cache_control(TfwHttpResp *resp, unsigned char *data, size_t len)
 			__FSM_I_MOVE(Resp_I_Ext);
 		if (IN_ALPHABET(c, hdr_a))
 			__FSM_I_MOVE_n(Resp_I_CC, 0);
-		if (c == '\r')
+		if (IS_CR_OR_LF(c))
 			return p - data;
 		return CSTR_NEQ;
 	}
@@ -2476,7 +2578,7 @@ __resp_parse_expires(TfwHttpResp *resp, unsigned char *data, size_t len)
 	__FSM_STATE(Resp_I_EoL) {
 		/* Skip rest of line: ' GMT'. */
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		if (__fsm_ch)
 			return __fsm_ch - data;
 		__FSM_I_MOVE_n(Resp_I_EoL, __fsm_sz);
@@ -2528,7 +2630,7 @@ __resp_parse_keep_alive(TfwHttpResp *resp, unsigned char *data, size_t len)
 	__FSM_STATE(Resp_I_Ext) {
 		unsigned char *comma;
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		comma = memchr(p, ',', __fsm_sz);
 		if (comma && (!__fsm_ch || (__fsm_ch && (comma < __fsm_ch))))
 			__FSM_I_MOVE_n(Resp_I_EoT, comma - p);
@@ -2545,7 +2647,7 @@ __resp_parse_keep_alive(TfwHttpResp *resp, unsigned char *data, size_t len)
 			__FSM_I_MOVE(Resp_I_Ext);
 		if (IN_ALPHABET(c, hdr_a))
 			__FSM_I_MOVE(Resp_I_KeepAlive);
-		if (c == '\r')
+		if (IS_CR_OR_LF(c))
 			return p - data;
 		return CSTR_NEQ;
 	}
@@ -2578,7 +2680,7 @@ __resp_parse_server(TfwHttpResp *resp, unsigned char *data, size_t len)
 		 *   null-terminated strings.
 		 */
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\r', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		if (__fsm_ch)
 			return __fsm_ch - data;
 		__FSM_I_MOVE_n(Resp_I_Server, __fsm_sz);
@@ -2592,7 +2694,6 @@ done:
 /* Main (parent) HTTP response processing states. */
 enum {
 	Resp_0,
-	Resp_EoL,
 	Resp_HttpVer,
 	Resp_HttpVerT1,
 	Resp_HttpVerT2,
@@ -2693,12 +2794,6 @@ enum {
 	Resp_HdrTransfer_EncodingV,
 	Resp_HdrOther,
 	Resp_HdrDone,
-	/* Body */
-	Resp_Body,
-	Resp_BodyChunkEoL,
-	Resp_BodyChunkEnd,
-	Resp_BodyReadChunk,
-	Resp_Done
 };
 
 int
@@ -2720,7 +2815,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 	/* ----------------    Status Line    ---------------- */
 
 	__FSM_STATE(Resp_0) {
-		if (unlikely(c == '\r' || c == '\n'))
+		if (unlikely(IS_CR_OR_LF(c)))
 			__FSM_MOVE(Resp_0);
 		/* fall through */
 	}
@@ -2784,10 +2879,10 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 	/* Reason-Phrase: just skip. */
 	__FSM_STATE(Resp_ReasonPhrase) {
 		__fsm_sz = len - (size_t)(p - data);
-		__fsm_ch = memchr(p, '\n', __fsm_sz);
+		__fsm_ch = memchreol(p, __fsm_sz);
 		if (__fsm_ch) {
-			__field_finish(msg, &resp->s_line, data, __fsm_ch + 1);
-			__FSM_MOVE_n(Resp_Hdr, __fsm_ch - p + 1);
+			__field_finish(msg, &resp->s_line, data, __fsm_ch);
+			__FSM_MOVE_n(RGen_EoL, __fsm_ch - p);
 		}
 		__FSM_MOVE_nf(Resp_ReasonPhrase, __fsm_sz, &resp->s_line);
 	}
@@ -2795,30 +2890,7 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 	/* ----------------    Header Lines    ---------------- */
 
 	/* Start of HTTP header or end of whole request. */
-	__FSM_STATE(Resp_Hdr) {
-		if (unlikely(c == '\r')) {
-			if (!(resp->body.flags & TFW_STR_COMPLETE)) {
-				tfw_http_msg_set_data(msg, &resp->crlf, p);
-				__FSM_MOVE(Resp_HdrDone);
-			} else
-				__FSM_MOVE(Resp_Done);
-		}
-		if (unlikely(c == '\n')) {
-			if (!(resp->body.flags & TFW_STR_COMPLETE)) {
-				/*
-				 * RFC 7230 3.5 allows single LF
-				 * without CR as an exception.
-				 */
-				if (unlikely(!resp->crlf.ptr))
-					tfw_http_msg_set_data(msg, &resp->crlf,
-							      p);
-				TFW_HTTP_INIT_BODY_PARSING(resp, Resp_Body);
-			} else {
-				r = TFW_PASS;
-				FSM_EXIT();
-			}
-		}
-
+	__FSM_STATE(RGen_Hdr) {
 		if (unlikely(!IN_ALPHABET(c, hdr_a)))
 			return TFW_BLOCK;
 
@@ -2875,7 +2947,9 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 		}
 	}
 
+	RGEN_EOL();
 	RGEN_LWS();
+	RGEN_LWS_empty();
 
 	/* Parse headers starting from 'C'. */
 	__FSM_STATE(Resp_HdrC) {
@@ -2971,18 +3045,9 @@ tfw_http_parse_resp(void *resp_data, unsigned char *data, size_t len)
 
 	TFW_HTTP_PARSE_HDR_OTHER(Resp);
 
-	TFW_HTTP_PARSE_LF(Resp);
-
-	/* Response headers are fully read. */
-	__FSM_STATE(Resp_HdrDone) {
-		if (c == '\n')
-			TFW_HTTP_INIT_BODY_PARSING(resp, Resp_Body);
-		return TFW_BLOCK;
-	}
-
 	/* ----------------    Response body    ---------------- */
 
-	TFW_HTTP_PARSE_BODY(Resp);
+	TFW_HTTP_PARSE_BODY();
 
 	/* ----------------    Improbable states    ---------------- */
 

--- a/tempesta_fw/str.h
+++ b/tempesta_fw/str.h
@@ -92,6 +92,9 @@
  * @skb		- socket buffer containign the string data;
  * @len		- total length of compund or plain string (HTTP message body
  *		  size can be extreme large, so we need 64 bits to handle it);
+ * @eolen	- the length of string's line endings, if present (as for now,
+ *		  it should be 0 if the string has no EOL at all, 1 for LF and
+ *		  2 for CRLF);
  * @flags	- 3 most significant bytes for number of chunks of compound
  * 		  string and the least significant byte for flags;
  */
@@ -99,6 +102,7 @@ typedef struct {
 	void		*ptr;
 	struct sk_buff	*skb;
 	unsigned long	len;
+	unsigned char	eolen;
 	unsigned int	flags;
 } TfwStr;
 
@@ -191,6 +195,34 @@ tfw_str_updlen(TfwStr *s, const char *curr_p)
 		n = curr_p - (char *)s->ptr;
 	}
 	s->len += n;
+}
+
+/**
+ * Returns EOL length
+ */
+static inline int
+tfw_str_eolen(const TfwStr *s)
+{
+	return s->eolen;
+}
+
+/**
+ * Updates EOL length value
+ */
+static inline void
+tfw_str_set_eolen(TfwStr *s, unsigned int eolen)
+{
+	BUG_ON(eolen > 2); /* LF and CRLF is the only valid EOL markers */
+	s->eolen = (unsigned char)eolen;
+}
+
+/**
+ * Returns total string length, including EOL
+ */
+static inline unsigned long
+tfw_str_total_len(const TfwStr *s)
+{
+	return s->len + s->eolen;
 }
 
 void tfw_str_del_chunk(TfwStr *str, int id);


### PR DESCRIPTION
This patch set intended to solve #444 issue by implementing generalized logic of EOL handling while parsing HTTP. Now, LF and CRLF is the only valid EOL markers. Also, this set adds support for tracking amount of EOL characters in TfwStr-strings.

Review history:
- https://github.com/natsys/tempesta/pull/451 (v1)
- https://github.com/natsys/tempesta/pull/453 (v2)

Changes since v2:
- fulfilling the CodingStyle (braces and fill-column limit)
- don't use separate header file for EOL
- cache's code reflects that s_line not contains EOL anymore
- __hdr_del / __hdr_sub are updated to use EOL
- common (raw) headers correctness checking (colon + alphabet)