### PR TITLE
Fix "BUG: using smp_processor_id() in preemptible" message

### DIFF
--- a/linux-4.1-tfw.patch
+++ b/linux-4.1-tfw.patch
@@ -1178,7 +1178,7 @@ index 075d2e7..cd94e94 100644
  /*
   * kmalloc_reserve is a wrapper around kmalloc_node_track_caller that tells
   * the caller if emergency pfmemalloc reserves are being used. If it is and
-@@ -148,6 +151,131 @@ out:
+@@ -148,6 +151,132 @@ out:
  
  	return obj;
  }
@@ -1253,13 +1253,14 @@ index 075d2e7..cd94e94 100644
 +{
 +	char *ptr;
 +	struct page *pg;
-+	TfwSkbMemPool *pools = this_cpu_ptr(pg_mpool);
++	TfwSkbMemPool *pools;
 +	unsigned int c, cn, o, l, po;
 +
 +	cn = PG_CHUNK_NUM(size);
 +	po = get_order(PG_ALLOC_SZ(size));
 +
 +	local_bh_disable();
++	pools = this_cpu_ptr(pg_mpool);
 +
 +	for (o = (cn == 1) ? 0 : (cn == 2) ? 1 : (cn <= 4) ? 2 : PG_LISTS_N;
 +	     o < PG_LISTS_N; ++o)


### PR DESCRIPTION
This patch fixes "BUG: using smp_processor_id() in preemptible" bug while running with CONFIG_DEBUG_PREEMPT enabled:

~~~
  Call Trace:
    [<ffffffff8161b6a1>] dump_stack+0x65/0x83
    [<ffffffff81374716>] check_preemption_disabled+0xe6/0xf0
    [<ffffffff81374737>] debug_smp_processor_id+0x17/0x20
    [<ffffffff81549e4e>] __pg_skb_alloc+0x2e/0x450
    [<ffffffff8154a2be>] __alloc_skb+0x4e/0x250
    [<ffffffff81374753>] ? __this_cpu_preempt_check+0x13/0x20
    [<ffffffff81545cf8>] sock_wmalloc+0x38/0xb0
    [<ffffffff815ecb84>] unix_stream_connect+0xb4/0x4a0
    [<ffffffff815439e3>] SyS_connect+0xe3/0x110
    [<ffffffff81620dee>] system_call_fastpath+0x12/0x71
  BUG: using smp_processor_id() in preemptible [00000000] code: sh/112
  caller is debug_smp_processor_id+0x17/0x20
~~~