### PR TITLE
Remove RCU-like access to sk->sk_user_data (#434)

### DIFF
--- a/tempesta_fw/connection.h
+++ b/tempesta_fw/connection.h
@@ -196,7 +196,7 @@ static inline void
 tfw_connection_link_from_sk(TfwConnection *conn, struct sock *sk)
 {
 	BUG_ON(sk->sk_user_data);
-	rcu_assign_sk_user_data(sk, conn);
+	sk->sk_user_data = conn;
 }
 
 /*
@@ -221,7 +221,7 @@ static inline void
 tfw_connection_unlink_from_sk(struct sock *sk)
 {
 	BUG_ON(!sk->sk_user_data);
-	rcu_assign_sk_user_data(sk, NULL);
+	sk->sk_user_data = NULL;
 }
 
 /*

--- a/tempesta_fw/sock.c
+++ b/tempesta_fw/sock.c
@@ -492,7 +492,7 @@ ss_tcp_process_skb(struct sock *sk, struct sk_buff *skb, int *processed)
 		tp->copied_seq += count;
 		*processed += count;
 
-		conn = rcu_dereference_sk_user_data(sk);
+		conn = sk->sk_user_data;
 		/*
 		 * If @sk_user_data is unset, then this connection
 		 * had been dropped in a parallel thread. Dropping
@@ -742,7 +742,7 @@ ss_tcp_state_change(struct sock *sk)
 
 	if (sk->sk_state == TCP_ESTABLISHED) {
 		/* Process the new TCP connection. */
-		SsProto *proto = rcu_dereference_sk_user_data(sk);
+		SsProto *proto = sk->sk_user_data;
 		struct sock *lsk = proto->listener;
 		int r;
 

--- a/tempesta_fw/sock_clnt.c
+++ b/tempesta_fw/sock_clnt.c
@@ -138,7 +138,7 @@ tfw_sock_clnt_new(struct sock *sk)
 	 * from referencing TfwListenSock{} while a new TfwConnection{}
 	 * object is not yet allocated/initialized.
 	 */
-	listen_sock_proto = rcu_dereference_sk_user_data(sk);
+	listen_sock_proto = sk->sk_user_data;
 	tfw_connection_unlink_from_sk(sk);
 
 	cli = tfw_client_obtain(sk);
@@ -186,7 +186,7 @@ err_client:
 static int
 tfw_sock_clnt_do_drop(struct sock *sk, const char *msg)
 {
-	TfwCliConnection *cli_conn = rcu_dereference_sk_user_data(sk);
+	TfwCliConnection *cli_conn = sk->sk_user_data;
 	TfwConnection *conn = &cli_conn->conn;
 
 	TFW_DBG3("%s: close client socket: sk=%p, conn=%p, client=%p\n",
@@ -348,7 +348,7 @@ tfw_listen_sock_start(TfwListenSock *ls)
 	 * That must be done before calling ss_set_listen() that uses SsProto.
 	 */
 	ls->sk = sk;
-	rcu_assign_sk_user_data(sk, ls);
+	sk->sk_user_data = ls;
 
 	/*
 	 * For listening sockets we use

--- a/tempesta_fw/sock_srv.c
+++ b/tempesta_fw/sock_srv.c
@@ -256,7 +256,7 @@ static int
 tfw_sock_srv_connect_complete(struct sock *sk)
 {
 	int r;
-	TfwSrvConnection *srv_conn = rcu_dereference_sk_user_data(sk);
+	TfwSrvConnection *srv_conn = sk->sk_user_data;
 	TfwConnection *conn = &srv_conn->conn;
 	TfwServer *srv = (TfwServer *)conn->peer;
 
@@ -283,7 +283,7 @@ tfw_sock_srv_connect_complete(struct sock *sk)
 static int
 tfw_sock_srv_do_failover(struct sock *sk, const char *msg)
 {
-	TfwConnection *conn = rcu_dereference_sk_user_data(sk);
+	TfwConnection *conn = sk->sk_user_data;
 	TfwServer *srv = (TfwServer *)conn->peer;
 
 	TFW_DBG_ADDR(msg, &srv->addr);

--- a/tempesta_fw/t/bomber.c
+++ b/tempesta_fw/t/bomber.c
@@ -128,7 +128,7 @@ __check_conn(TfwBmbConn *conn)
 static int
 tfw_bmb_conn_compl(struct sock *sk)
 {
-	TfwBmbConn *conn = rcu_dereference_sk_user_data(sk);
+	TfwBmbConn *conn = sk->sk_user_data;
 
 	BUG_ON(!conn);
 	conn->proto.type = TFW_BMB_SK_ACTIVE;
@@ -143,7 +143,7 @@ tfw_bmb_conn_compl(struct sock *sk)
 static int
 tfw_bmb_conn_drop(struct sock *sk)
 {
-	TfwBmbConn *conn = rcu_dereference_sk_user_data(sk);
+	TfwBmbConn *conn = sk->sk_user_data;
 
 	BUG_ON(!conn);
 	__check_conn(conn);
@@ -202,7 +202,7 @@ tfw_bmb_connect(TfwBmbTask *task, TfwBmbConn *conn)
 	}
 
 	ss_proto_init(&conn->proto, &bmb_hooks, TFW_BMB_SK_INACTIVE);
-	rcu_assign_sk_user_data(sk, &conn->proto);
+	sk->sk_user_data = &conn->proto;
 	ss_set_callbacks(sk);
 	conn->sk = sk;
 	conn->task = task;

--- a/tempesta_fw/t/sync_sockets/kernel/sync_kclient.c
+++ b/tempesta_fw/t/sync_sockets/kernel/sync_kclient.c
@@ -112,7 +112,7 @@ kclient_connect(int descidx)
 		return ret;
 	}
 	ss_proto_init(&desc->proto, &kclient_hooks, descidx);
-	rcu_assign_sk_user_data(sk, &desc->proto);
+	sk->sk_user_data = &desc->proto;
 	ss_set_callbacks(sk);
 	ret = ss_connect(sk, &kclient_server_address.sa,
 			 tfw_addr_sa_len(&kclient_server_address), 0);
@@ -134,7 +134,7 @@ kclient_connect_complete(struct sock *sk)
 {
 	int descidx;
 	kclient_desc_t *desc;
-	SsProto *proto = (SsProto *)rcu_dereference_sk_user_data(sk);
+	SsProto *proto = sk->sk_user_data;
 
 	BUG_ON(proto == NULL);
 
@@ -157,7 +157,7 @@ kclient_connection_close(struct sock *sk)
 {
 	int descidx;
 	kclient_desc_t *desc;
-	SsProto *proto = (SsProto *)rcu_dereference_sk_user_data(sk);
+	SsProto *proto = sk->sk_user_data;
 
 	BUG_ON(proto == NULL);
 
@@ -181,7 +181,7 @@ kclient_connection_error(struct sock *sk)
 {
 	int descidx;
 	kclient_desc_t *desc;
-	SsProto *proto = (SsProto *)rcu_dereference_sk_user_data(sk);
+	SsProto *proto = sk->sk_user_data;
 
 	BUG_ON(proto == NULL);
 


### PR DESCRIPTION
Replace it with plain and simple access. Now that Tempesta code
runs completely under socket lock, the use of RCU-like access
is no longer needed.